### PR TITLE
feat: add prp-ralph-cancel canonical + 4 adapters

### DIFF
--- a/adapters/antigravity/prp-ralph-cancel.md
+++ b/adapters/antigravity/prp-ralph-cancel.md
@@ -1,0 +1,19 @@
+---
+description: Cancel active PRP Ralph loop
+---
+
+# Cancel PRP Ralph Loop
+
+1. **Check**: `test -f .claude/prp-ralph.state.md` → ACTIVE or NOT_FOUND.
+2. **If NOT_FOUND**: "No active Ralph loop found."
+3. **If ACTIVE**:
+   - Read state: `head -20 .claude/prp-ralph.state.md` — extract iteration and plan path.
+   - Remove: `rm .claude/prp-ralph.state.md`
+   - Report: iteration stopped at, plan path, work preserved in modified files and git commits.
+   - To resume: `/prp-ralph {plan_path}` or `/prp-implement {plan_path}`
+
+## Success Criteria
+
+- LOOP_DETECTED: State file checked
+- STATE_REMOVED: State file deleted
+- WORK_PRESERVED: No code reverted

--- a/adapters/codex/prp-ralph-cancel/SKILL.md
+++ b/adapters/codex/prp-ralph-cancel/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: prp-ralph-cancel
+description: Cancel an active PRP Ralph loop and preserve work done so far.
+metadata:
+  short-description: Cancel Ralph loop
+---
+
+# Cancel PRP Ralph Loop
+
+## Mission
+
+Cancel an active Ralph loop. Preserve all work done so far — only remove the state file.
+
+## Step 1: Check Loop Status
+
+```bash
+test -f .claude/prp-ralph.state.md && echo "ACTIVE" || echo "NOT_FOUND"
+```
+
+| Result | Action |
+|--------|--------|
+| NOT_FOUND | Report: "No active Ralph loop found." STOP. |
+| ACTIVE | Proceed to Step 2. |
+
+## Step 2: Read Current State
+
+```bash
+head -20 .claude/prp-ralph.state.md
+```
+
+Extract from YAML frontmatter:
+- `iteration`: current iteration number
+- `plan_path`: path to the plan being executed
+
+## Step 3: Remove State File
+
+```bash
+rm .claude/prp-ralph.state.md
+```
+
+## Step 4: Report
+
+```markdown
+## Ralph Loop Cancelled
+
+**Was at**: Iteration {N}
+**Plan**: {plan_path}
+
+The loop has been stopped. Your work so far is preserved in:
+- Modified files (check `git status`)
+- Git commits (if any were made)
+
+To resume later:
+- Run `$prp-ralph {plan_path}` to start fresh
+- Or continue manually with `$prp-implement {plan_path}`
+```
+
+## Success Criteria
+
+- LOOP_DETECTED: State file checked for existence
+- STATE_REMOVED: `.claude/prp-ralph.state.md` deleted (if existed)
+- WORK_PRESERVED: No code changes reverted — only state file removed

--- a/adapters/gemini/ralph-cancel.toml
+++ b/adapters/gemini/ralph-cancel.toml
@@ -1,0 +1,17 @@
+description = "Cancel active PRP Ralph loop"
+prompt = """# Cancel PRP Ralph Loop
+
+1. **Check**: `test -f .claude/prp-ralph.state.md` → ACTIVE or NOT_FOUND.
+2. **If NOT_FOUND**: "No active Ralph loop found."
+3. **If ACTIVE**:
+   - Read state: `head -20 .claude/prp-ralph.state.md` — extract iteration and plan path.
+   - Remove: `rm .claude/prp-ralph.state.md`
+   - Report: iteration stopped at, plan path, work preserved in modified files and git commits.
+   - To resume: `/prp:ralph {plan_path}` or `/prp:implement {plan_path}`
+
+## Success Criteria
+
+- LOOP_DETECTED: State file checked
+- STATE_REMOVED: State file deleted
+- WORK_PRESERVED: No code reverted
+"""

--- a/adapters/opencode/ralph-cancel.md
+++ b/adapters/opencode/ralph-cancel.md
@@ -1,0 +1,20 @@
+---
+description: Cancel active PRP Ralph loop
+agent: build
+---
+
+# Cancel PRP Ralph Loop
+
+1. **Check**: `test -f .claude/prp-ralph.state.md` → ACTIVE or NOT_FOUND.
+2. **If NOT_FOUND**: "No active Ralph loop found."
+3. **If ACTIVE**:
+   - Read state: `head -20 .claude/prp-ralph.state.md` — extract iteration and plan path.
+   - Remove: `rm .claude/prp-ralph.state.md`
+   - Report: iteration stopped at, plan path, work preserved in modified files and git commits.
+   - To resume: `/prp:ralph {plan_path}` or `/prp:implement {plan_path}`
+
+## Success Criteria
+
+- LOOP_DETECTED: State file checked
+- STATE_REMOVED: State file deleted
+- WORK_PRESERVED: No code reverted

--- a/prompts/ralph-cancel.md
+++ b/prompts/ralph-cancel.md
@@ -1,0 +1,58 @@
+# Cancel PRP Ralph Loop
+
+## Mission
+
+Cancel an active Ralph loop and preserve work done so far.
+
+---
+
+## Steps
+
+1. **Check if loop is active**
+
+   ```bash
+   test -f .claude/prp-ralph.state.md && echo "ACTIVE" || echo "NOT_FOUND"
+   ```
+
+2. **If NOT_FOUND**: Report "No active Ralph loop found."
+
+3. **If ACTIVE**:
+
+   a. Read the state file to get current iteration:
+
+   ```bash
+   head -20 .claude/prp-ralph.state.md
+   ```
+
+   b. Extract iteration number and plan path from the YAML frontmatter.
+
+   c. Remove the state file:
+
+   ```bash
+   rm .claude/prp-ralph.state.md
+   ```
+
+   d. Report:
+
+   ```markdown
+   ## Ralph Loop Cancelled
+
+   **Was at**: Iteration {N}
+   **Plan**: {plan_path}
+
+   The loop has been stopped. Your work so far is preserved in:
+   - Modified files (check `git status`)
+   - Git commits (if any were made)
+
+   To resume later:
+   - Run the ralph workflow with the same plan to start fresh
+   - Or continue manually with the implement workflow
+   ```
+
+---
+
+## Success Criteria
+
+- **LOOP_DETECTED**: State file checked for existence
+- **STATE_REMOVED**: `.claude/prp-ralph.state.md` deleted (if existed)
+- **WORK_PRESERVED**: No code changes reverted — only state file removed


### PR DESCRIPTION
## Summary

Last remaining gap — `prp-ralph-cancel` previously only existed in the claude-code adapter. Now has canonical + all 4 adapters.

## Files (5)

| File | Format |
|------|--------|
| `prompts/ralph-cancel.md` | Canonical |
| `adapters/antigravity/prp-ralph-cancel.md` | Compressed |
| `adapters/opencode/ralph-cancel.md` | Compressed |
| `adapters/gemini/ralph-cancel.toml` | TOML |
| `adapters/codex/prp-ralph-cancel/SKILL.md` | Phased SKILL.md |

Simple command: check state file exists → read iteration → remove state → report.

## Test plan

- [ ] Each adapter follows its format convention
- [ ] No claude-code references
- [ ] Success Criteria present in all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)