### PR TITLE
docs: v2.0 → v2.1 migration guide

### DIFF
--- a/docs/migration/v2.0-to-v2.1.md
+++ b/docs/migration/v2.0-to-v2.1.md
@@ -9,21 +9,21 @@ However, this release introduces significant new capabilities across all adapter
 ## Quick Update
 
 ```bash
-# Submodule users
+# Pull latest (works for both submodule and local clone)
 cd .prp && git pull --rebase origin main && cd ..
 
-# Local clone users
-cd .prp && git pull --rebase origin main && cd ..
-
-# Re-install to update symlinks (recommended)
+# Re-install to update symlinks and hooks (recommended)
 cd .prp && ./scripts/install.sh && cd ..
+
+# If using global PRP with symlink (e.g., ops setup):
+cd .prp && ./scripts/install.sh "$(pwd)" && cd ..
 ```
 
 ## What Changed
 
 ### 8 Commands Upgraded to Cross-Adapter Parity
 
-All 5 adapters (Claude Code, Codex, OpenCode, Gemini CLI, Antigravity) now have equivalent quality for these commands:
+All 5 tool-specific adapters (Claude Code, Codex, OpenCode, Gemini CLI, Antigravity) now have equivalent quality for these commands:
 
 | Command | What's New |
 |---------|-----------|
@@ -36,6 +36,8 @@ All 5 adapters (Claude Code, Codex, OpenCode, Gemini CLI, Antigravity) now have 
 | `run-all` | Dry-run mode, Ralph mode support, full state management, incremental re-verify |
 | `plan` | Full PRD parsing, toolchain detection, technical design sections, confidence scoring |
 
+> **Note**: `review-agents` and `feature-review-agents` remain Claude Code-exclusive (they use multi-agent dispatch via Task tool). Other adapters achieve equivalent review quality through multi-pass architecture in the `review` command.
+
 ### New Features (All Adapters)
 
 #### 1. Phase Checkpoints
@@ -44,7 +46,13 @@ Every command now includes explicit `PHASE_X_CHECKPOINT` markers between phases.
 
 **No action needed** — checkpoints are embedded in the prompts and used automatically.
 
-#### 2. Implementation Report Enrichment (`pr` command)
+#### 2. Agent Mode Detection
+
+All commands now detect when running as a sub-agent inside a multi-agents framework (via `[WORKSPACE CONTEXT]` marker). When detected, they skip redundant phases (CLAUDE.md reading, toolchain detection, context extraction) to save tokens.
+
+**No action needed** — optimization is automatic when orchestrated by a multi-agents framework.
+
+#### 3. Implementation Report Enrichment (`pr` command)
 
 When creating a PR, the `pr` command now automatically checks for an implementation report at `.prp-output/reports/*-report*.md`. If found, it enriches the PR body with:
 - Implementation summary
@@ -53,34 +61,43 @@ When creating a PR, the `pr` command now automatically checks for an implementat
 
 **No action needed** — works automatically when reports exist.
 
-#### 3. Plan-Aware Commit Messages (`commit` command)
+#### 4. Plan-Aware Commit Messages (`commit` command)
 
 The `commit` command now checks `.prp-output/plans/completed/` for a plan matching the current branch. If found, the commit message body includes plan context (summary, task count).
 
 **No action needed** — works automatically when completed plans exist.
 
-#### 4. Manifest-First Artifact Discovery (`cleanup` command)
+#### 5. Manifest-First Artifact Discovery (`cleanup` command)
 
 The `cleanup` command now checks `.prp-output/manifests/{BRANCH}.json` before falling back to glob-based artifact search. Manifests provide exact artifact paths, avoiding false matches.
 
 **Optional**: Manifests are created by newer versions of `implement` and `run-all`. Existing projects without manifests will use the glob fallback (same behavior as v2.0).
 
-#### 5. Orphaned State File Cleanup (`cleanup` command)
+#### 6. Orphaned State File Cleanup (`cleanup` command)
 
 When cleaning a branch, `cleanup` now removes the associated `.claude/prp-run-all.state.md` file if it exists and references the cleaned branch.
 
 **No action needed** — prevents stale state files from accumulating.
 
-#### 6. Incremental Re-verify (`run-all` command)
+#### 7. Incremental Re-verify (`run-all` command)
 
 In the review-fix cycle (Step 6.4), `run-all` now passes `--since-last-review` to the review command. This reviews only changes since the last review, saving tokens.
 
 **No action needed** — used automatically during re-verify cycles.
 
-#### 7. Dry-Run Mode (`run-all` command)
+#### 8. Dry-Run Mode (`run-all` command)
+
+Now available in **all adapters** (previously Claude Code only):
 
 ```bash
-/prp-run-all "Add user auth" --dry-run
+# Claude Code
+/prp-core:run-all "Add user auth" --dry-run
+
+# Codex
+$prp-run-all "Add user auth" --dry-run
+
+# OpenCode / Gemini
+/prp:run-all "Add user auth" --dry-run
 ```
 
 Previews all steps that would execute, including:
@@ -90,30 +107,45 @@ Previews all steps that would execute, including:
 
 Then exits without making any changes.
 
-#### 8. Ralph Mode in All Adapters (`run-all` command)
+#### 9. Ralph Mode in All Adapters (`run-all` command)
 
 Previously, `--ralph` was supported only in Claude Code. Now all adapters support it:
 
 ```bash
-# Any adapter
-{TOOL}:run-all "Complex feature" --ralph --ralph-max-iter 5
+# Claude Code
+/prp-core:run-all "Complex feature" --ralph --ralph-max-iter 5
+
+# Codex
+$prp-run-all "Complex feature" --ralph --ralph-max-iter 5
 ```
 
 This enables autonomous implementation loops that retry until all validations pass.
 
 **Note**: Ralph requires the stop hook to be registered. Run `cd .prp && ./scripts/install.sh` to ensure it's set up.
 
-## New Flags Summary
+## New & Expanded Flags
+
+### Flags Now Available in All Adapters (previously Claude Code only)
 
 | Flag | Command | Description |
 |------|---------|-------------|
 | `--dry-run` | `run-all` | Preview without executing |
 | `--ralph` | `run-all` | Use autonomous implementation loop |
 | `--ralph-max-iter N` | `run-all` | Max ralph iterations (default: 10) |
+
+### New Flags (introduced in v2.1.0)
+
+| Flag | Command | Description |
+|------|---------|-------------|
 | `--since-last-review` | `review` | Incremental review (only changes since last review) |
 | `--metrics` | `review` | Show aggregate review metrics summary |
-| `perf` | `review` | Performance review pass (auto-dispatched or explicit) |
-| `a11y` | `review` | Accessibility review pass (auto-dispatched or explicit) |
+
+### New Review Aspects
+
+| Aspect | Command | Description |
+|--------|---------|-------------|
+| `perf` | `review` | Performance pass — auto-dispatched when DB/API/async patterns detected, or explicit |
+| `a11y` | `review` | Accessibility pass — auto-dispatched when UI/frontend files detected, or explicit |
 
 ## New Artifact Paths
 
@@ -152,8 +184,14 @@ New tests verify:
 
 ### What if I use a non-Claude Code adapter?
 
-All 5 adapters received the same upgrades. Your workflow is the same — just with more depth in each command's execution.
+All 5 tool-specific adapters received the same upgrades. Your workflow is the same — just with more depth in each command's execution.
 
-### What about the 9 commands not yet upgraded?
+### What about the commands not yet upgraded?
 
-Commands `prd`, `design`, `feature-review`, `issue-investigate`, `issue-fix`, `debug`, `ralph`, `rollback`, and `ralph-cancel` were not part of v2.1.0. They continue to work as before and will be upgraded in a future release.
+9 commands were not part of v2.1.0: `prd`, `design`, `feature-review`, `issue-investigate`, `issue-fix`, `debug`, `ralph`, `rollback`, and `ralph-cancel`. They continue to work as before and will be upgraded in a future release (tracked in [#20](https://github.com/gobikom/prp-framework/issues/20)).
+
+Additionally, `review-agents` and `feature-review-agents` remain Claude Code-exclusive. Other adapters achieve equivalent quality through multi-pass architecture in the standard `review` and `feature-review` commands.
+
+### Where can I find v2.0.0 changes?
+
+See the [CHANGELOG](../../CHANGELOG.md) for the full v2.0.0 release notes, including `--no-interact`, `--resume`, `--fix-severity`, `--prp-path`, and other features introduced in the initial cross-tool portability release.


### PR DESCRIPTION
## Summary

- Add `docs/migration/v2.0-to-v2.1.md` documenting all new features, flags, and artifact paths
- Non-breaking release — no manual migration required

## Contents

- Quick update instructions (submodule, local clone, re-install)
- 8 commands upgraded with what's new per command
- 8 new features explained (checkpoints, report enrichment, plan-aware commit, manifest-first, state cleanup, incremental re-verify, dry-run, ralph mode)
- New flags summary table
- New artifact paths table
- Parity test updates
- FAQ (5 questions)

## Test plan

- [x] No code changes — documentation only
- [ ] Review content accuracy against CHANGELOG v2.1.0

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)