### PR TITLE
feat: add 21 content-level parity tests (45 → 66)

### DIFF
--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -447,6 +447,22 @@ Generate final report:
 
 ---
 
+---
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Plan step succeeds but implement fails partway | STOP - implement generates partial report + pr-context before stopping. Use `--resume` to continue. |
+| Branch already exists from prior aborted run | Use existing branch if on it, or switch to it. State file tracks which branch. |
+| State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
+| Lock file exists (concurrent run) | Check age - if >2 hours, treat as stale and remove. Otherwise STOP. |
+| Review finds no issues | Skip review-fix, proceed directly to summary. |
+| All review-fix issues skipped | Report skipped issues in summary. Still counts as reviewed. |
+| `--ralph` but hook not registered | STOP with install instructions. |
+| Disk full during state write | STOP - state may be corrupted. Delete state file and restart. |
+| PR creation fails (auth/permission) | STOP - commit is safe on branch. User can manually create PR. |
+
 ## Success Criteria
 
 - PLAN_CREATED: Plan exists and is valid

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -764,6 +764,22 @@ With context file from implement step, review costs ~15-30K tokens.
 
 ---
 
+---
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Plan step succeeds but implement fails partway | STOP - implement generates partial report + pr-context before stopping. Use `--resume` to continue. |
+| Branch already exists from prior aborted run | Use existing branch if on it, or switch to it. State file tracks which branch. |
+| State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
+| Lock file exists (concurrent run) | Check age - if >2 hours, treat as stale and remove. Otherwise STOP. |
+| Review finds no issues | Skip review-fix, proceed directly to summary. |
+| All review-fix issues skipped | Report skipped issues in summary. Still counts as reviewed. |
+| `--ralph` but hook not registered | STOP with install instructions. |
+| Disk full during state write | STOP - state may be corrupted. Delete state file and restart. |
+| PR creation fails (auth/permission) | STOP - commit is safe on branch. User can manually create PR. |
+
 ## Success Criteria
 
 - **SKILL_TOOL_USED**: All `/prp-*` commands invoked via Skill tool (not inlined)

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -449,6 +449,22 @@ $prp-run-all Add JWT auth --fix-severity critical,high # Fix only blocking issue
 
 ---
 
+---
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Plan step succeeds but implement fails partway | STOP - implement generates partial report + pr-context before stopping. Use `--resume` to continue. |
+| Branch already exists from prior aborted run | Use existing branch if on it, or switch to it. State file tracks which branch. |
+| State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
+| Lock file exists (concurrent run) | Check age - if >2 hours, treat as stale and remove. Otherwise STOP. |
+| Review finds no issues | Skip review-fix, proceed directly to summary. |
+| All review-fix issues skipped | Report skipped issues in summary. Still counts as reviewed. |
+| `--ralph` but hook not registered | STOP with install instructions. |
+| Disk full during state write | STOP - state may be corrupted. Delete state file and restart. |
+| PR creation fails (auth/permission) | STOP - commit is safe on branch. User can manually create PR. |
+
 ## Success Criteria
 
 - PLAN_CREATED: Plan exists and is valid

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -445,6 +445,22 @@ Generate final report:
 
 ---
 
+---
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Plan step succeeds but implement fails partway | STOP - implement generates partial report + pr-context before stopping. Use `--resume` to continue. |
+| Branch already exists from prior aborted run | Use existing branch if on it, or switch to it. State file tracks which branch. |
+| State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
+| Lock file exists (concurrent run) | Check age - if >2 hours, treat as stale and remove. Otherwise STOP. |
+| Review finds no issues | Skip review-fix, proceed directly to summary. |
+| All review-fix issues skipped | Report skipped issues in summary. Still counts as reviewed. |
+| `--ralph` but hook not registered | STOP with install instructions. |
+| Disk full during state write | STOP - state may be corrupted. Delete state file and restart. |
+| PR creation fails (auth/permission) | STOP - commit is safe on branch. User can manually create PR. |
+
 ## Success Criteria
 
 - PLAN_CREATED: Plan exists and is valid

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -448,6 +448,22 @@ Generate final report:
 
 ---
 
+---
+
+## Edge Cases
+
+| Situation | Action |
+|-----------|--------|
+| Plan step succeeds but implement fails partway | STOP - implement generates partial report + pr-context before stopping. Use `--resume` to continue. |
+| Branch already exists from prior aborted run | Use existing branch if on it, or switch to it. State file tracks which branch. |
+| State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
+| Lock file exists (concurrent run) | Check age - if >2 hours, treat as stale and remove. Otherwise STOP. |
+| Review finds no issues | Skip review-fix, proceed directly to summary. |
+| All review-fix issues skipped | Report skipped issues in summary. Still counts as reviewed. |
+| `--ralph` but hook not registered | STOP with install instructions. |
+| Disk full during state write | STOP - state may be corrupted. Delete state file and restart. |
+| PR creation fails (auth/permission) | STOP - commit is safe on branch. User can manually create PR. |
+
 ## Success Criteria
 
 - PLAN_CREATED: Plan exists and is valid

--- a/tests/adapters/parity.bats
+++ b/tests/adapters/parity.bats
@@ -394,7 +394,114 @@ check_all_6() {
 }
 
 # ─────────────────────────────────────────────
-# 16. Claude Code-specific commands exist
+# 16. Content-level parity — Success Criteria in all commands
+# ─────────────────────────────────────────────
+
+@test "all review files have Success Criteria" {
+    check_all_6 "Success Criteria" "review"
+}
+
+@test "all implement files have Success Criteria" {
+    check_all_6 "Success Criteria" "implement"
+}
+
+@test "all review-fix files have Success Criteria" {
+    check_all_6 "Success Criteria" "review-fix"
+}
+
+@test "all pr files have Success Criteria" {
+    check_all_6 "Success Criteria" "pr"
+}
+
+@test "all cleanup files have Success Criteria" {
+    check_all_6 "Success Criteria" "cleanup"
+}
+
+@test "all run-all files have Success Criteria" {
+    check_all_6 "Success Criteria" "run-all"
+}
+
+@test "all plan files have Success Criteria" {
+    check_all_6 "Success Criteria\|success_criteria" "plan"
+}
+
+@test "all debug files have Success Criteria" {
+    check_all_6 "Success Criteria" "debug"
+}
+
+# ─────────────────────────────────────────────
+# 17. Content-level parity — Edge Cases
+# ─────────────────────────────────────────────
+
+@test "all review files have Edge Cases" {
+    check_all_6 "Edge Case" "review"
+}
+
+@test "all review-fix files have Edge Cases" {
+    check_all_6 "Edge Case" "review-fix"
+}
+
+@test "all pr files have Edge Cases" {
+    check_all_6 "Edge Case\|Handling Edge" "pr"
+}
+
+@test "all cleanup files have Edge Cases" {
+    check_all_6 "Edge Case" "cleanup"
+}
+
+@test "all run-all files have Edge Cases" {
+    check_all_6 "Edge Case" "run-all"
+}
+
+# ─────────────────────────────────────────────
+# 18. Artifact suffix — adapters use their own tool suffix
+# ─────────────────────────────────────────────
+
+@test "codex review uses -codex suffix" {
+    grep -q "\-codex" "$FRAMEWORK_DIR/adapters/codex/prp-review/SKILL.md"
+}
+
+@test "opencode review uses -opencode suffix" {
+    grep -q "\-opencode" "$FRAMEWORK_DIR/adapters/opencode/review.md"
+}
+
+@test "antigravity review uses -antigravity suffix" {
+    grep -q "\-antigravity" "$FRAMEWORK_DIR/adapters/antigravity/prp-review.md"
+}
+
+@test "gemini review uses -gemini suffix" {
+    grep -q "\-gemini" "$FRAMEWORK_DIR/adapters/gemini/review.toml"
+}
+
+@test "prompts review uses -{TOOL} suffix" {
+    grep -q "\-{TOOL}" "$FRAMEWORK_DIR/prompts/review.md"
+}
+
+# ─────────────────────────────────────────────
+# 19. Prompt drift detection — key section counts
+# ─────────────────────────────────────────────
+
+@test "prompts/ and codex have similar checkpoint counts for implement" {
+    PROMPT_COUNT=$(grep -c "CHECKPOINT" "$FRAMEWORK_DIR/prompts/implement.md")
+    CODEX_COUNT=$(grep -c "CHECKPOINT" "$FRAMEWORK_DIR/adapters/codex/prp-implement/SKILL.md")
+    # Allow ±1 difference
+    [ "$(( PROMPT_COUNT - CODEX_COUNT ))" -le 1 ] && [ "$(( CODEX_COUNT - PROMPT_COUNT ))" -le 1 ]
+}
+
+@test "prompts/ and codex have similar checkpoint counts for review-fix" {
+    PROMPT_COUNT=$(grep -c "CHECKPOINT" "$FRAMEWORK_DIR/prompts/review-fix.md")
+    CODEX_COUNT=$(grep -c "CHECKPOINT" "$FRAMEWORK_DIR/adapters/codex/prp-review-fix/SKILL.md")
+    [ "$(( PROMPT_COUNT - CODEX_COUNT ))" -le 1 ] && [ "$(( CODEX_COUNT - PROMPT_COUNT ))" -le 1 ]
+}
+
+@test "prompts/ and codex have similar checkpoint counts for run-all" {
+    PROMPT_COUNT=$(grep -c "CHECKPOINT" "$FRAMEWORK_DIR/prompts/run-all.md")
+    CODEX_COUNT=$(grep -c "CHECKPOINT" "$FRAMEWORK_DIR/adapters/codex/prp-run-all/SKILL.md")
+    [ "$(( PROMPT_COUNT - CODEX_COUNT ))" -le 1 ] && [ "$(( CODEX_COUNT - PROMPT_COUNT ))" -le 1 ]
+}
+
+# ─────────────────────────────────────────────
+# 20. Claude Code-specific commands exist
 # ─────────────────────────────────────────────
 @test "claude-code has prp-rollback command" {
     [ -f "$FRAMEWORK_DIR/adapters/claude-code/prp-rollback.md" ]


### PR DESCRIPTION
## Summary

- Add 21 new content-level parity tests (45 → 66 total)
- Fix missing Edge Cases section in all 5 run-all adapter files

## New Tests

| Category | Tests | What's Verified |
|----------|-------|-----------------|
| Success Criteria | 8 | All 8 core commands have Success Criteria in every adapter |
| Edge Cases | 5 | review, review-fix, pr, cleanup, run-all have Edge Cases |
| Artifact Suffix | 5 | Each adapter uses correct suffix (-codex, -opencode, etc.) |
| Prompt Drift | 3 | Checkpoint counts match between prompts/ and codex (±1) |

## Bug Fix

- run-all Edge Cases section was only in `prompts/run-all.md` — now propagated to all 5 adapter files

## Test plan

- [x] 66/66 parity tests pass

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)