### PR TITLE
feat: P3 — Kimi docs, manifest schema, install version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ prp-framework/
 │   ├── opencode/               # OpenCode commands (16 commands)
 │   ├── gemini/                 # Gemini commands (16 commands)
 │   ├── antigravity/            # Antigravity workflows (16 workflows)
-│   └── generic/                # AGENTS.md for Kimi/others
+│   └── generic/                # AGENTS.md for Kimi and other AI tools (natural language)
 ├── docs/                       # Documentation
 │   └── SCRIPTS-REFERENCE.md   # Detailed script docs
 ├── scripts/                    # Installation & utility scripts

--- a/docs/MANIFEST-SCHEMA.md
+++ b/docs/MANIFEST-SCHEMA.md
@@ -1,0 +1,92 @@
+# Pipeline Manifest Schema
+
+## Overview
+
+Pipeline manifests track exact artifact paths for a branch, enabling precise cleanup without glob-based discovery.
+
+## Location
+
+```
+.prp-output/manifests/{BRANCH}.json
+```
+
+Example: `.prp-output/manifests/feature-auth.json`
+
+## Schema
+
+```json
+{
+  "branch": "feature/auth",
+  "pr_number": 42,
+  "created": "2026-03-28T10:30:00Z",
+  "artifacts": {
+    "plan": ".prp-output/plans/completed/auth-20260328-1030.plan.md",
+    "report": ".prp-output/reports/auth-report-20260328-1130.md",
+    "context": ".prp-output/reviews/pr-context-feature-auth.md",
+    "reviews": [
+      ".prp-output/reviews/pr-42-review-codex.md"
+    ],
+    "fixes": [
+      ".prp-output/reviews/pr-42-fix-summary-20260328-1200.md"
+    ]
+  }
+}
+```
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branch` | string | Branch name |
+| `pr_number` | number | Associated PR number (0 if no PR yet) |
+| `created` | string | ISO 8601 timestamp |
+| `artifacts` | object | Artifact paths |
+
+## Artifact Fields (all optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `artifacts.plan` | string | Path to completed plan |
+| `artifacts.report` | string | Path to implementation report |
+| `artifacts.context` | string | Path to PR review context |
+| `artifacts.reviews` | string[] | Paths to review artifacts |
+| `artifacts.fixes` | string[] | Paths to fix summary artifacts |
+
+## Validation Rules
+
+1. **File must be valid JSON** — malformed manifests should be ignored (fallback to glob)
+2. **`branch` field must exist** — used to match with cleanup target
+3. **`artifacts` field must be an object** — even if empty
+4. **Paths are relative to project root** — not absolute paths
+5. **Missing artifact paths are OK** — cleanup skips entries that don't exist on disk
+
+## Usage in Commands
+
+### `cleanup` (Phase 3.2)
+
+```
+1. Check .prp-output/manifests/{BRANCH}.json
+2. If valid JSON with artifacts → use exact paths
+3. If invalid/missing → fallback to glob discovery
+4. After archiving → rm -f .prp-output/manifests/{BRANCH}.json
+```
+
+### `implement` / `run-all`
+
+After generating artifacts, optionally write manifest:
+
+```bash
+mkdir -p .prp-output/manifests
+cat > ".prp-output/manifests/${BRANCH}.json" << EOF
+{
+  "branch": "${BRANCH}",
+  "pr_number": 0,
+  "created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "artifacts": {
+    "plan": "${PLAN_PATH}",
+    "report": "${REPORT_PATH}",
+    "context": "${CONTEXT_PATH}"
+  }
+}
+EOF
+```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,6 +25,27 @@ fi
 
 echo "Framework directory: $FRAMEWORK_DIR"
 echo "Project directory: $PROJECT_DIR"
+
+# Detect version from CHANGELOG
+CURRENT_VERSION=$(grep -oP '## \[\K[0-9]+\.[0-9]+\.[0-9]+' "$FRAMEWORK_DIR/CHANGELOG.md" 2>/dev/null | head -1)
+if [ -n "$CURRENT_VERSION" ]; then
+    echo "Framework version: v${CURRENT_VERSION}"
+fi
+
+# Check for previous install version
+PREV_VERSION=""
+if [ -f "$PROJECT_DIR/.claude/prp-version" ]; then
+    PREV_VERSION=$(cat "$PROJECT_DIR/.claude/prp-version" 2>/dev/null)
+fi
+
+if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "$CURRENT_VERSION" ] && [ -n "$CURRENT_VERSION" ]; then
+    echo -e "${YELLOW}Upgrading from v${PREV_VERSION} → v${CURRENT_VERSION}${NC}"
+    # Check for migration guide
+    MIGRATION_FILE="$FRAMEWORK_DIR/docs/migration/v${PREV_VERSION%%.*}.${PREV_VERSION#*.}-to-v${CURRENT_VERSION}.md"
+    if [ -f "$MIGRATION_FILE" ]; then
+        echo -e "  Migration guide: ${GREEN}${MIGRATION_FILE}${NC}"
+    fi
+fi
 echo ""
 
 # Auto-recover: restore agent/hook files if a previous buggy install converted
@@ -394,3 +415,9 @@ printf "    %-14s %s\n" "Kimi/Generic:" "Use natural language (see AGENTS.md)"
 echo ""
 echo "Documentation: $FRAMEWORK_DIR/docs/"
 echo ""
+
+# Save installed version for upgrade detection
+if [ -n "$CURRENT_VERSION" ]; then
+    mkdir -p "$PROJECT_DIR/.claude"
+    echo "$CURRENT_VERSION" > "$PROJECT_DIR/.claude/prp-version"
+fi


### PR DESCRIPTION
## Summary

Batch P3 improvements — 3 issues in 1 PR.

### #24 Fix Kimi adapter reference
- Clarify README: generic/ adapter serves Kimi + other tools via natural language
- No dedicated adapter needed — existing setup is correct

### #25 Manifest schema documentation
- New: `docs/MANIFEST-SCHEMA.md` with JSON schema, required fields, validation rules
- Documents `.prp-output/manifests/{BRANCH}.json` structure for cleanup/implement/run-all

### #26 Install.sh version check
- Detects version from CHANGELOG.md on install
- Saves to `.claude/prp-version` for upgrade detection
- Shows upgrade notice + migration guide link when version changes

## Test plan

- [x] No existing tests broken (docs + install script only)
- [ ] Manual: run install.sh, verify version saved to .claude/prp-version

Closes #24, closes #25, closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)