### PR TITLE
release: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,37 @@ _No unreleased changes._
 
 ---
 
+## [2.2.0] — 2026-03-28
+
+**Auto-Generation & Cross-Adapter Expansion Release** — Adapter files are now auto-generated from `prompts/` as single source of truth. Marketing/bot commands expanded to all 5 adapters. Monorepo support added.
+
+### Added
+
+- **Adapter auto-generation** (`scripts/generate-adapters.py`) — generates all 140 adapter files (28 commands × 5 adapters) from canonical `prompts/` with a single command. Supports `--dry-run`, `--diff`, `--adapter` filter. Eliminates manual 5-adapter sync and prevents cross-adapter drift. (PR #34)
+- **`adapters.yml`** — central config defining transformation rules for all adapters: file patterns, placeholder mappings (`{ARGS}` → `$ARGUMENTS`/`{{args}}`), frontmatter formats, tool command syntax
+- **Overlay system** (`prompts/overlays/`) — tool-specific content (XML wrapping, agent strategies) that extends base prompts without modifying them. Currently used for Claude Code `plan` XML structure
+- **9 marketing/bot commands cross-adapter** — `landing`, `demo`, `pitch`, `competitor`, `intent`, `flow`, `prompt-eng`, `voice-ux`, `integration` now available in all 5 adapters (were Claude Code-only). Total commands: 19 → 28. (PR #35)
+- **`group_dirs`** config — routes marketing/bot commands to separate directories for Claude Code (`claude-code-marketing/`, `claude-code-bot/`) while other adapters keep all commands in one directory
+- **Monorepo support** — auto-detects pnpm workspaces, Turborepo, Nx, Lerna, yarn/npm workspaces. New `--package <name>` flag for `plan`, `implement`, and `run-all` to scope to a specific package. Per-tool scoped validation commands (e.g., `pnpm --filter api test`, `turbo run lint --filter=api`, `nx run api:lint`). (PR #36)
+- **Monorepo-aware commits** — `commit` adds package scope to conventional commit format: `feat(api): description`
+- **`requirements.txt`** — Python dependencies for the generator (`pyyaml>=6.0,<7.0`)
+- **17 new tests** — overlay XML output, monorepo detection, group_dirs routing, placeholder substitution, TOML validity, idempotency. Total: 244 → 271
+
+### Changed
+
+- **`docs/CONTRIBUTING.md`** — new editing workflow: edit `prompts/` → run `generate-adapters.py` → test. Manual adapter editing no longer needed
+- **Adapter files** — all 95 existing + 45 new adapter files are now generated from canonical prompts, fixing accumulated drift from manual editing
+
+### Migration
+
+See `docs/migration/v2.1-to-v2.2.md` for details. Key changes:
+
+- **Do NOT manually edit files in `adapters/`** — they are now generated. Edit `prompts/` instead, then run `python3 scripts/generate-adapters.py`
+- **New dependency**: Python 3.10+ with `pyyaml` for running the generator
+- **No breaking changes** — all existing commands, flags, and artifacts work identically
+
+---
+
 ## [2.1.0] — 2026-03-28
 
 **Cross-Adapter Parity Release** — All 8 core commands upgraded to feature parity across 5 adapters. +11,835 lines across 32 files. Every adapter now has phase checkpoints, full templates, failure diagnostics, and unique features ported across tools.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ PRP (Plan-Review-PR) Framework is a portable, tool-agnostic workflow system for 
 ✅ **Complete Workflows** - PRD → Design → Plan → Implement → Review → Commit → PR
 ✅ **Resilient Automation** - State management with `--resume`, review-fix loops, coverage enforcement (90%)
 ✅ **Quality Built-in** - TDD approach, conditional design docs, pre-commit checks, security/performance validation
-✅ **100% Workflow Parity** - All tools follow the same workflow steps with equivalent review depth (11-pass review across all adapters). Claude Code adds 19 commands, 30 agents, hooks, and skills; other adapters use multi-pass architecture for the same quality.
+✅ **100% Workflow Parity** - 28 commands across all 5 adapters (19 core + 4 marketing + 5 bot), auto-generated from canonical prompts to guarantee zero drift
+✅ **Auto-Generation** - Single source of truth in `prompts/` — edit once, generate all 5 adapters with `scripts/generate-adapters.py`
+✅ **Monorepo Support** - Auto-detects pnpm workspaces, Turborepo, Nx, Lerna. `--package` flag scopes plan/implement/run-all to a specific package
 ✅ **Claude Code Advanced** - 30 specialized agents, skills, hooks for enhanced workflows
-✅ **Domain Extensions** - Marketing automation and AI Bot development command packs
+✅ **Domain Extensions** - Marketing automation and AI Bot development command packs in all adapters
 
 ## Quick Start
 
@@ -211,7 +213,7 @@ prp-framework/
 │   ├── issue-fix.md
 │   └── feature-review.md
 ├── adapters/                   # Tool-specific adapters
-│   ├── claude-code/            # Claude Code core commands (19 commands)
+│   ├── claude-code/            # Claude Code core commands (19 commands, auto-generated)
 │   ├── claude-code-marketing/  # Marketing commands (4 commands)
 │   ├── claude-code-bot/        # AI Bot commands (5 commands)
 │   ├── claude-code-agents/     # Claude Code agents (30 agents)

--- a/docs/migration/v2.1-to-v2.2.md
+++ b/docs/migration/v2.1-to-v2.2.md
@@ -1,0 +1,94 @@
+# Migration Guide: v2.1 → v2.2
+
+## Overview
+
+v2.2.0 introduces adapter auto-generation, marketing/bot cross-adapter support, and monorepo support. **No breaking changes** — all existing commands, flags, and artifacts work identically.
+
+## What Changed
+
+### 1. Adapter files are now auto-generated
+
+**Before**: Edit `prompts/{cmd}.md` → manually edit 5 adapter files
+**After**: Edit `prompts/{cmd}.md` → run `python3 scripts/generate-adapters.py`
+
+**Action required**: None for users. For contributors:
+
+```bash
+# Install Python dependency (one-time)
+pip install pyyaml
+
+# After editing any prompt
+python3 scripts/generate-adapters.py
+bats tests/adapters/parity.bats
+```
+
+**Do NOT manually edit files in `adapters/`** — they will be overwritten by the generator.
+
+### 2. New commands available (19 → 28)
+
+9 marketing/bot commands previously available only in Claude Code are now in all adapters:
+
+| Command | Codex | OpenCode | Gemini | Antigravity |
+|---------|-------|----------|--------|-------------|
+| `landing` | `$prp-landing` | `/prp:landing` | `/landing` | `/prp-landing` |
+| `demo` | `$prp-demo` | `/prp:demo` | `/demo` | `/prp-demo` |
+| `pitch` | `$prp-pitch` | `/prp:pitch` | `/pitch` | `/prp-pitch` |
+| `competitor` | `$prp-competitor` | `/prp:competitor` | `/competitor` | `/prp-competitor` |
+| `intent` | `$prp-intent` | `/prp:intent` | `/intent` | `/prp-intent` |
+| `flow` | `$prp-flow` | `/prp:flow` | `/flow` | `/prp-flow` |
+| `prompt-eng` | `$prp-prompt-eng` | `/prp:prompt-eng` | `/prompt-eng` | `/prp-prompt-eng` |
+| `voice-ux` | `$prp-voice-ux` | `/prp:voice-ux` | `/voice-ux` | `/prp-voice-ux` |
+| `integration` | `$prp-integration` | `/prp:integration` | `/integration` | `/prp-integration` |
+
+**Action required**: Re-run `install.sh` to get the new commands:
+
+```bash
+cd .prp && ./scripts/install.sh
+```
+
+### 3. Monorepo support
+
+New `--package` flag for monorepo projects:
+
+```bash
+# Scope plan to a specific package
+/prp-plan "add auth" --package api
+
+# Full workflow with package scoping
+/prp-run-all "add auth" --package api
+```
+
+Auto-detects: pnpm workspaces, Turborepo, Nx, Lerna, yarn/npm workspaces.
+
+**Action required**: None. Feature is opt-in via `--package` flag.
+
+### 4. New files in the repo
+
+| File | Purpose |
+|------|---------|
+| `adapters.yml` | Adapter transformation config |
+| `scripts/generate-adapters.py` | Auto-generation script |
+| `prompts/overlays/` | Tool-specific overlay content |
+| `requirements.txt` | Python dependencies |
+| `prompts/{9 new files}` | Canonical marketing/bot prompts |
+
+## Update Steps
+
+```bash
+# 1. Pull latest
+cd .prp
+git pull origin main
+
+# 2. Re-install (picks up new commands + version)
+./scripts/install.sh
+
+# 3. Verify
+cat .claude/prp-version  # Should show 2.2.0
+```
+
+## Compatibility
+
+- All v2.1.0 artifacts (plans, reports, reviews) remain valid
+- All v2.1.0 flags work identically
+- `--resume` state files from v2.1.0 are compatible
+- No adapter directory changes (symlinks still work)


### PR DESCRIPTION
## v2.2.0 Release

Release docs for v2.2.0 (features already merged in PRs #34, #35, #36).

### Changes in this PR
- CHANGELOG.md with full v2.2.0 entry
- Migration guide (docs/migration/v2.1-to-v2.2.md)
- README updated with new features

### Features in this release
1. **Adapter auto-generation** — single source of truth in prompts/
2. **28 commands** — 9 mkt/bot commands now in all 5 adapters
3. **Monorepo support** — --package flag for pnpm/Turbo/Nx/Lerna/yarn

271 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)