### PR TITLE
fix: treat test gaps as actionable fixes in review-fix

### DIFF
--- a/adapters/antigravity/prp-review-fix.md
+++ b/adapters/antigravity/prp-review-fix.md
@@ -213,6 +213,10 @@ Extract all issues grouped by severity. Look for sections:
 - **Codex adapters**: Use parenthetical labels (e.g., "Critical (block merge)"). Match on the keyword before the parenthetical.
 - **Standard review**: Uses "Pass" column (pass name). Agents-review uses "Agent" column (agent name). Both are valid source identifiers.
 
+**Severity promotion for test gaps:**
+- Test gaps flagged as "NOT TESTED" that cover **security guarantees** (auth, PKCE, token handling, encryption, access control, input validation) → promote to **Critical** regardless of original label.
+- Other test gaps → keep original severity but **do not skip** — write the missing tests as part of the fix.
+
 **PHASE_1_CHECKPOINT:**
 - [ ] Review artifact resolved (auto or user-selected)
 - [ ] PR number identified
@@ -338,6 +342,7 @@ For each issue in the batch:
 
 **Rules:**
 - Fix what the review flagged + same-pattern siblings across all PR files
+- **Test gaps are code fixes** — when the review flags missing tests (e.g., "NOT TESTED", "no test for X", "test gap"), write the missing tests as part of the fix. Test gaps covering security guarantees (auth, encryption, access control, input validation) should be treated as Critical regardless of how the review labeled them.
 - Don't refactor surrounding code or fix unrelated issues
 - Match existing code style
 - If a fix is ambiguous or risky → SKIP and add to skip log

--- a/adapters/claude-code/prp-review-fix.md
+++ b/adapters/claude-code/prp-review-fix.md
@@ -215,6 +215,10 @@ Extract all issues grouped by severity. Look for sections:
 - **Codex adapters**: Use parenthetical labels (e.g., "Critical (block merge)"). Match on the keyword before the parenthetical.
 - **Standard review**: Uses "Pass" column (pass name). Agents-review uses "Agent" column (agent name). Both are valid source identifiers.
 
+**Severity promotion for test gaps:**
+- Test gaps flagged as "NOT TESTED" that cover **security guarantees** (auth, PKCE, token handling, encryption, access control, input validation) → promote to **Critical** regardless of original label.
+- Other test gaps → keep original severity but **do not skip** — write the missing tests as part of the fix.
+
 **PHASE_1_CHECKPOINT:**
 - [ ] Review artifact resolved (auto or user-selected)
 - [ ] PR number identified
@@ -340,6 +344,7 @@ For each issue in the batch:
 
 **Rules:**
 - Fix what the review flagged + same-pattern siblings across all PR files
+- **Test gaps are code fixes** — when the review flags missing tests (e.g., "NOT TESTED", "no test for X", "test gap"), write the missing tests as part of the fix. Test gaps covering security guarantees (auth, encryption, access control, input validation) should be treated as Critical regardless of how the review labeled them.
 - Don't refactor surrounding code or fix unrelated issues
 - Match existing code style
 - If a fix is ambiguous or risky → SKIP and add to skip log

--- a/adapters/codex/prp-review-fix/SKILL.md
+++ b/adapters/codex/prp-review-fix/SKILL.md
@@ -216,6 +216,10 @@ Extract all issues grouped by severity. Look for sections:
 - **Codex adapters**: Use parenthetical labels (e.g., "Critical (block merge)"). Match on the keyword before the parenthetical.
 - **Standard review**: Uses "Pass" column (pass name). Agents-review uses "Agent" column (agent name). Both are valid source identifiers.
 
+**Severity promotion for test gaps:**
+- Test gaps flagged as "NOT TESTED" that cover **security guarantees** (auth, PKCE, token handling, encryption, access control, input validation) → promote to **Critical** regardless of original label.
+- Other test gaps → keep original severity but **do not skip** — write the missing tests as part of the fix.
+
 **PHASE_1_CHECKPOINT:**
 - [ ] Review artifact resolved (auto or user-selected)
 - [ ] PR number identified
@@ -341,6 +345,7 @@ For each issue in the batch:
 
 **Rules:**
 - Fix what the review flagged + same-pattern siblings across all PR files
+- **Test gaps are code fixes** — when the review flags missing tests (e.g., "NOT TESTED", "no test for X", "test gap"), write the missing tests as part of the fix. Test gaps covering security guarantees (auth, encryption, access control, input validation) should be treated as Critical regardless of how the review labeled them.
 - Don't refactor surrounding code or fix unrelated issues
 - Match existing code style
 - If a fix is ambiguous or risky → SKIP and add to skip log

--- a/adapters/gemini/review-fix.toml
+++ b/adapters/gemini/review-fix.toml
@@ -212,6 +212,10 @@ Extract all issues grouped by severity. Look for sections:
 - **Codex adapters**: Use parenthetical labels (e.g., "Critical (block merge)"). Match on the keyword before the parenthetical.
 - **Standard review**: Uses "Pass" column (pass name). Agents-review uses "Agent" column (agent name). Both are valid source identifiers.
 
+**Severity promotion for test gaps:**
+- Test gaps flagged as "NOT TESTED" that cover **security guarantees** (auth, PKCE, token handling, encryption, access control, input validation) → promote to **Critical** regardless of original label.
+- Other test gaps → keep original severity but **do not skip** — write the missing tests as part of the fix.
+
 **PHASE_1_CHECKPOINT:**
 - [ ] Review artifact resolved (auto or user-selected)
 - [ ] PR number identified
@@ -337,6 +341,7 @@ For each issue in the batch:
 
 **Rules:**
 - Fix what the review flagged + same-pattern siblings across all PR files
+- **Test gaps are code fixes** — when the review flags missing tests (e.g., "NOT TESTED", "no test for X", "test gap"), write the missing tests as part of the fix. Test gaps covering security guarantees (auth, encryption, access control, input validation) should be treated as Critical regardless of how the review labeled them.
 - Don't refactor surrounding code or fix unrelated issues
 - Match existing code style
 - If a fix is ambiguous or risky → SKIP and add to skip log

--- a/adapters/opencode/review-fix.md
+++ b/adapters/opencode/review-fix.md
@@ -214,6 +214,10 @@ Extract all issues grouped by severity. Look for sections:
 - **Codex adapters**: Use parenthetical labels (e.g., "Critical (block merge)"). Match on the keyword before the parenthetical.
 - **Standard review**: Uses "Pass" column (pass name). Agents-review uses "Agent" column (agent name). Both are valid source identifiers.
 
+**Severity promotion for test gaps:**
+- Test gaps flagged as "NOT TESTED" that cover **security guarantees** (auth, PKCE, token handling, encryption, access control, input validation) → promote to **Critical** regardless of original label.
+- Other test gaps → keep original severity but **do not skip** — write the missing tests as part of the fix.
+
 **PHASE_1_CHECKPOINT:**
 - [ ] Review artifact resolved (auto or user-selected)
 - [ ] PR number identified
@@ -339,6 +343,7 @@ For each issue in the batch:
 
 **Rules:**
 - Fix what the review flagged + same-pattern siblings across all PR files
+- **Test gaps are code fixes** — when the review flags missing tests (e.g., "NOT TESTED", "no test for X", "test gap"), write the missing tests as part of the fix. Test gaps covering security guarantees (auth, encryption, access control, input validation) should be treated as Critical regardless of how the review labeled them.
 - Don't refactor surrounding code or fix unrelated issues
 - Match existing code style
 - If a fix is ambiguous or risky → SKIP and add to skip log

--- a/prompts/review-fix.md
+++ b/prompts/review-fix.md
@@ -210,6 +210,10 @@ Extract all issues grouped by severity. Look for sections:
 - **Codex adapters**: Use parenthetical labels (e.g., "Critical (block merge)"). Match on the keyword before the parenthetical.
 - **Standard review**: Uses "Pass" column (pass name). Agents-review uses "Agent" column (agent name). Both are valid source identifiers.
 
+**Severity promotion for test gaps:**
+- Test gaps flagged as "NOT TESTED" that cover **security guarantees** (auth, PKCE, token handling, encryption, access control, input validation) → promote to **Critical** regardless of original label.
+- Other test gaps → keep original severity but **do not skip** — write the missing tests as part of the fix.
+
 **PHASE_1_CHECKPOINT:**
 - [ ] Review artifact resolved (auto or user-selected)
 - [ ] PR number identified
@@ -335,6 +339,7 @@ For each issue in the batch:
 
 **Rules:**
 - Fix what the review flagged + same-pattern siblings across all PR files
+- **Test gaps are code fixes** — when the review flags missing tests (e.g., "NOT TESTED", "no test for X", "test gap"), write the missing tests as part of the fix. Test gaps covering security guarantees (auth, encryption, access control, input validation) should be treated as Critical regardless of how the review labeled them.
 - Don't refactor surrounding code or fix unrelated issues
 - Match existing code style
 - If a fix is ambiguous or risky → SKIP and add to skip log


### PR DESCRIPTION
## Summary

`prp-review-fix` now treats test gaps as code fixes instead of skipping them.

Fixes #53

## Changes

Two additions to `prompts/review-fix.md`:

1. **New rule in Fix Loop (§4.1)**: "Test gaps are code fixes — when the review flags missing tests, write the missing tests as part of the fix. Test gaps covering security guarantees should be treated as Critical."

2. **Severity promotion in Parse Issues (§1.5)**: Test gaps marked "NOT TESTED" that cover security guarantees (auth, PKCE, token handling, encryption, access control) are promoted to Critical regardless of original label.

## Testing

- All 5 adapters regenerated (claude-code, codex, opencode, gemini, antigravity)
- Prompt-only change — no runtime code affected