### PR TITLE
fix(run-all): enforce zero-issues target — skipped ≠ resolved

### DIFF
--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -428,6 +428,16 @@ This will: detect toolchain, load artifact directly, fix issues by severity, val
 **DO NOT**: Manually read and fix issues yourself, run validation separately.
 **CHECKPOINT**: Did you invoke `/prp-review-fix`? If not → STOP → invoke it.
 
+**Capture review-fix outcome** for Step 6.4:
+
+| review-fix result | Set |
+|-------------------|-----|
+| All issues fixed (skipped_count = 0) | `PENDING_SKIPPED = false` |
+| Some fixed, some skipped (skipped_count > 0) | `PENDING_SKIPPED = true`, `SKIPPED_COUNT = N` |
+| All issues skipped (fixed_count = 0, skipped_count > 0) | `PENDING_SKIPPED = true`, `ALL_SKIPPED = true` |
+
+**Zero-issues bar**: skipped issues are NOT resolved — they are deferred. Do not proceed to Step 7 as if done.
+
 #### 6.4 Re-verify
 
 Increment: `REVIEW_CYCLE += 1`
@@ -436,11 +446,22 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 **Re-verify always uses single-agent review** (`/prp-review`) regardless of `REVIEW_SINGLE_AGENT` setting — multi-agent re-verify is wasteful for incremental changes.
 
-Use `/prp-review` with `{PR_NUMBER} --since-last-review` for **incremental review** (only reviews changes since last review — saves tokens).
+**Re-verify mode depends on `PENDING_SKIPPED`:**
+
+| PENDING_SKIPPED | Re-verify command | Why |
+|-----------------|-------------------|-----|
+| `false` (all fixed) | `/prp-review {PR_NUMBER} --since-last-review` (incremental) | Only new code changed — delta review saves tokens |
+| `true` (some/all skipped) | `/prp-review {PR_NUMBER} --context` (FULL review) | Skipped items did NOT change code but STILL need to re-surface — incremental delta would miss them and produce false "0 issues" |
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
 → **Return to Step 6.2** to evaluate results.
+
+**Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
+- Do NOT loop another round — review-fix has no additional tooling to resolve these.
+- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Set `REVIEW_VERDICT = "needs_manual_fix"`.
+- Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 
 ---
 
@@ -636,7 +657,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 | State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
 | Lock file exists (concurrent run) | Check age — if >2 hours, treat as stale and remove. Otherwise STOP. |
 | Review finds no issues | Skip review-fix, proceed directly to summary. |
-| All review-fix issues skipped | Report skipped issues in summary. Still counts as "reviewed". |
+| All review-fix issues skipped (fixed_count=0) | Do NOT proceed to summary as "done". Set `ALL_SKIPPED = true` and follow Step 6.4 Escalation Guard: after round 2 with all-skipped, create escalation GH issue + set `REVIEW_VERDICT = needs_manual_fix` + skip merge. Zero-issues target is not satisfied by "we tried review-fix and it gave up". |
+| Some review-fix issues skipped | Re-verify with FULL review (`--context`, not `--since-last-review`) so skipped items re-surface in next 6.2 evaluation. See Step 6.4 table. |
 | `--ralph` but hook not registered | STOP with install instructions. |
 | Disk full during state write | STOP — state may be corrupted. Delete state file and restart. |
 | PR creation fails (auth/permission) | STOP — commit is safe on branch. User can manually create PR. |
@@ -661,7 +683,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 - PR_CREATED: PR exists (unless --no-pr)
 - REVIEWED: Review posted with verdict (unless --skip-review)
 - INCREMENTAL_REVIEW: Re-verify uses `--since-last-review` for token optimization
-- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues or MAX_CYCLES reached
+- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
+- NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -430,6 +430,16 @@ This will: detect toolchain, load artifact directly, fix issues by severity, val
 **DO NOT**: Manually read and fix issues yourself, run validation separately.
 **CHECKPOINT**: Did you invoke `/prp-core:prp-review-fix`? If not → STOP → invoke it.
 
+**Capture review-fix outcome** for Step 6.4:
+
+| review-fix result | Set |
+|-------------------|-----|
+| All issues fixed (skipped_count = 0) | `PENDING_SKIPPED = false` |
+| Some fixed, some skipped (skipped_count > 0) | `PENDING_SKIPPED = true`, `SKIPPED_COUNT = N` |
+| All issues skipped (fixed_count = 0, skipped_count > 0) | `PENDING_SKIPPED = true`, `ALL_SKIPPED = true` |
+
+**Zero-issues bar**: skipped issues are NOT resolved — they are deferred. Do not proceed to Step 7 as if done.
+
 #### 6.4 Re-verify
 
 Increment: `REVIEW_CYCLE += 1`
@@ -438,11 +448,22 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 **Re-verify always uses single-agent review** (`/prp-core:prp-review`) regardless of `REVIEW_SINGLE_AGENT` setting — multi-agent re-verify is wasteful for incremental changes.
 
-Use `/prp-core:prp-review` with `{PR_NUMBER} --since-last-review` for **incremental review** (only reviews changes since last review — saves tokens).
+**Re-verify mode depends on `PENDING_SKIPPED`:**
+
+| PENDING_SKIPPED | Re-verify command | Why |
+|-----------------|-------------------|-----|
+| `false` (all fixed) | `/prp-core:prp-review {PR_NUMBER} --since-last-review` (incremental) | Only new code changed — delta review saves tokens |
+| `true` (some/all skipped) | `/prp-core:prp-review {PR_NUMBER} --context` (FULL review) | Skipped items did NOT change code but STILL need to re-surface — incremental delta would miss them and produce false "0 issues" |
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
 → **Return to Step 6.2** to evaluate results.
+
+**Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
+- Do NOT loop another round — review-fix has no additional tooling to resolve these.
+- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Set `REVIEW_VERDICT = "needs_manual_fix"`.
+- Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 
 ---
 
@@ -638,7 +659,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 | State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
 | Lock file exists (concurrent run) | Check age — if >2 hours, treat as stale and remove. Otherwise STOP. |
 | Review finds no issues | Skip review-fix, proceed directly to summary. |
-| All review-fix issues skipped | Report skipped issues in summary. Still counts as "reviewed". |
+| All review-fix issues skipped (fixed_count=0) | Do NOT proceed to summary as "done". Set `ALL_SKIPPED = true` and follow Step 6.4 Escalation Guard: after round 2 with all-skipped, create escalation GH issue + set `REVIEW_VERDICT = needs_manual_fix` + skip merge. Zero-issues target is not satisfied by "we tried review-fix and it gave up". |
+| Some review-fix issues skipped | Re-verify with FULL review (`--context`, not `--since-last-review`) so skipped items re-surface in next 6.2 evaluation. See Step 6.4 table. |
 | `--ralph` but hook not registered | STOP with install instructions. |
 | Disk full during state write | STOP — state may be corrupted. Delete state file and restart. |
 | PR creation fails (auth/permission) | STOP — commit is safe on branch. User can manually create PR. |
@@ -663,7 +685,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 - PR_CREATED: PR exists (unless --no-pr)
 - REVIEWED: Review posted with verdict (unless --skip-review)
 - INCREMENTAL_REVIEW: Re-verify uses `--since-last-review` for token optimization
-- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues or MAX_CYCLES reached
+- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
+- NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -431,6 +431,16 @@ This will: detect toolchain, load artifact directly, fix issues by severity, val
 **DO NOT**: Manually read and fix issues yourself, run validation separately.
 **CHECKPOINT**: Did you invoke `$prp-review-fix`? If not → STOP → invoke it.
 
+**Capture review-fix outcome** for Step 6.4:
+
+| review-fix result | Set |
+|-------------------|-----|
+| All issues fixed (skipped_count = 0) | `PENDING_SKIPPED = false` |
+| Some fixed, some skipped (skipped_count > 0) | `PENDING_SKIPPED = true`, `SKIPPED_COUNT = N` |
+| All issues skipped (fixed_count = 0, skipped_count > 0) | `PENDING_SKIPPED = true`, `ALL_SKIPPED = true` |
+
+**Zero-issues bar**: skipped issues are NOT resolved — they are deferred. Do not proceed to Step 7 as if done.
+
 #### 6.4 Re-verify
 
 Increment: `REVIEW_CYCLE += 1`
@@ -439,11 +449,22 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 **Re-verify always uses single-agent review** (`$prp-review`) regardless of `REVIEW_SINGLE_AGENT` setting — multi-agent re-verify is wasteful for incremental changes.
 
-Use `$prp-review` with `{PR_NUMBER} --since-last-review` for **incremental review** (only reviews changes since last review — saves tokens).
+**Re-verify mode depends on `PENDING_SKIPPED`:**
+
+| PENDING_SKIPPED | Re-verify command | Why |
+|-----------------|-------------------|-----|
+| `false` (all fixed) | `$prp-review {PR_NUMBER} --since-last-review` (incremental) | Only new code changed — delta review saves tokens |
+| `true` (some/all skipped) | `$prp-review {PR_NUMBER} --context` (FULL review) | Skipped items did NOT change code but STILL need to re-surface — incremental delta would miss them and produce false "0 issues" |
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
 → **Return to Step 6.2** to evaluate results.
+
+**Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
+- Do NOT loop another round — review-fix has no additional tooling to resolve these.
+- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Set `REVIEW_VERDICT = "needs_manual_fix"`.
+- Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 
 ---
 
@@ -639,7 +660,8 @@ $prp-run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
 | State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
 | Lock file exists (concurrent run) | Check age — if >2 hours, treat as stale and remove. Otherwise STOP. |
 | Review finds no issues | Skip review-fix, proceed directly to summary. |
-| All review-fix issues skipped | Report skipped issues in summary. Still counts as "reviewed". |
+| All review-fix issues skipped (fixed_count=0) | Do NOT proceed to summary as "done". Set `ALL_SKIPPED = true` and follow Step 6.4 Escalation Guard: after round 2 with all-skipped, create escalation GH issue + set `REVIEW_VERDICT = needs_manual_fix` + skip merge. Zero-issues target is not satisfied by "we tried review-fix and it gave up". |
+| Some review-fix issues skipped | Re-verify with FULL review (`--context`, not `--since-last-review`) so skipped items re-surface in next 6.2 evaluation. See Step 6.4 table. |
 | `--ralph` but hook not registered | STOP with install instructions. |
 | Disk full during state write | STOP — state may be corrupted. Delete state file and restart. |
 | PR creation fails (auth/permission) | STOP — commit is safe on branch. User can manually create PR. |
@@ -664,7 +686,8 @@ $prp-run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
 - PR_CREATED: PR exists (unless --no-pr)
 - REVIEWED: Review posted with verdict (unless --skip-review)
 - INCREMENTAL_REVIEW: Re-verify uses `--since-last-review` for token optimization
-- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues or MAX_CYCLES reached
+- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
+- NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -427,6 +427,16 @@ This will: detect toolchain, load artifact directly, fix issues by severity, val
 **DO NOT**: Manually read and fix issues yourself, run validation separately.
 **CHECKPOINT**: Did you invoke `/review-fix`? If not → STOP → invoke it.
 
+**Capture review-fix outcome** for Step 6.4:
+
+| review-fix result | Set |
+|-------------------|-----|
+| All issues fixed (skipped_count = 0) | `PENDING_SKIPPED = false` |
+| Some fixed, some skipped (skipped_count > 0) | `PENDING_SKIPPED = true`, `SKIPPED_COUNT = N` |
+| All issues skipped (fixed_count = 0, skipped_count > 0) | `PENDING_SKIPPED = true`, `ALL_SKIPPED = true` |
+
+**Zero-issues bar**: skipped issues are NOT resolved — they are deferred. Do not proceed to Step 7 as if done.
+
 #### 6.4 Re-verify
 
 Increment: `REVIEW_CYCLE += 1`
@@ -435,11 +445,22 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 **Re-verify always uses single-agent review** (`/review`) regardless of `REVIEW_SINGLE_AGENT` setting — multi-agent re-verify is wasteful for incremental changes.
 
-Use `/review` with `{PR_NUMBER} --since-last-review` for **incremental review** (only reviews changes since last review — saves tokens).
+**Re-verify mode depends on `PENDING_SKIPPED`:**
+
+| PENDING_SKIPPED | Re-verify command | Why |
+|-----------------|-------------------|-----|
+| `false` (all fixed) | `/review {PR_NUMBER} --since-last-review` (incremental) | Only new code changed — delta review saves tokens |
+| `true` (some/all skipped) | `/review {PR_NUMBER} --context` (FULL review) | Skipped items did NOT change code but STILL need to re-surface — incremental delta would miss them and produce false "0 issues" |
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
 → **Return to Step 6.2** to evaluate results.
+
+**Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
+- Do NOT loop another round — review-fix has no additional tooling to resolve these.
+- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Set `REVIEW_VERDICT = "needs_manual_fix"`.
+- Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 
 ---
 
@@ -635,7 +656,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 | State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
 | Lock file exists (concurrent run) | Check age — if >2 hours, treat as stale and remove. Otherwise STOP. |
 | Review finds no issues | Skip review-fix, proceed directly to summary. |
-| All review-fix issues skipped | Report skipped issues in summary. Still counts as "reviewed". |
+| All review-fix issues skipped (fixed_count=0) | Do NOT proceed to summary as "done". Set `ALL_SKIPPED = true` and follow Step 6.4 Escalation Guard: after round 2 with all-skipped, create escalation GH issue + set `REVIEW_VERDICT = needs_manual_fix` + skip merge. Zero-issues target is not satisfied by "we tried review-fix and it gave up". |
+| Some review-fix issues skipped | Re-verify with FULL review (`--context`, not `--since-last-review`) so skipped items re-surface in next 6.2 evaluation. See Step 6.4 table. |
 | `--ralph` but hook not registered | STOP with install instructions. |
 | Disk full during state write | STOP — state may be corrupted. Delete state file and restart. |
 | PR creation fails (auth/permission) | STOP — commit is safe on branch. User can manually create PR. |
@@ -660,7 +682,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 - PR_CREATED: PR exists (unless --no-pr)
 - REVIEWED: Review posted with verdict (unless --skip-review)
 - INCREMENTAL_REVIEW: Re-verify uses `--since-last-review` for token optimization
-- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues or MAX_CYCLES reached
+- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
+- NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -429,6 +429,16 @@ This will: detect toolchain, load artifact directly, fix issues by severity, val
 **DO NOT**: Manually read and fix issues yourself, run validation separately.
 **CHECKPOINT**: Did you invoke `/prp:review-fix`? If not → STOP → invoke it.
 
+**Capture review-fix outcome** for Step 6.4:
+
+| review-fix result | Set |
+|-------------------|-----|
+| All issues fixed (skipped_count = 0) | `PENDING_SKIPPED = false` |
+| Some fixed, some skipped (skipped_count > 0) | `PENDING_SKIPPED = true`, `SKIPPED_COUNT = N` |
+| All issues skipped (fixed_count = 0, skipped_count > 0) | `PENDING_SKIPPED = true`, `ALL_SKIPPED = true` |
+
+**Zero-issues bar**: skipped issues are NOT resolved — they are deferred. Do not proceed to Step 7 as if done.
+
 #### 6.4 Re-verify
 
 Increment: `REVIEW_CYCLE += 1`
@@ -437,11 +447,22 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 **Re-verify always uses single-agent review** (`/prp:review`) regardless of `REVIEW_SINGLE_AGENT` setting — multi-agent re-verify is wasteful for incremental changes.
 
-Use `/prp:review` with `{PR_NUMBER} --since-last-review` for **incremental review** (only reviews changes since last review — saves tokens).
+**Re-verify mode depends on `PENDING_SKIPPED`:**
+
+| PENDING_SKIPPED | Re-verify command | Why |
+|-----------------|-------------------|-----|
+| `false` (all fixed) | `/prp:review {PR_NUMBER} --since-last-review` (incremental) | Only new code changed — delta review saves tokens |
+| `true` (some/all skipped) | `/prp:review {PR_NUMBER} --context` (FULL review) | Skipped items did NOT change code but STILL need to re-surface — incremental delta would miss them and produce false "0 issues" |
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
 → **Return to Step 6.2** to evaluate results.
+
+**Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
+- Do NOT loop another round — review-fix has no additional tooling to resolve these.
+- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Set `REVIEW_VERDICT = "needs_manual_fix"`.
+- Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 
 ---
 
@@ -637,7 +658,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 | State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
 | Lock file exists (concurrent run) | Check age — if >2 hours, treat as stale and remove. Otherwise STOP. |
 | Review finds no issues | Skip review-fix, proceed directly to summary. |
-| All review-fix issues skipped | Report skipped issues in summary. Still counts as "reviewed". |
+| All review-fix issues skipped (fixed_count=0) | Do NOT proceed to summary as "done". Set `ALL_SKIPPED = true` and follow Step 6.4 Escalation Guard: after round 2 with all-skipped, create escalation GH issue + set `REVIEW_VERDICT = needs_manual_fix` + skip merge. Zero-issues target is not satisfied by "we tried review-fix and it gave up". |
+| Some review-fix issues skipped | Re-verify with FULL review (`--context`, not `--since-last-review`) so skipped items re-surface in next 6.2 evaluation. See Step 6.4 table. |
 | `--ralph` but hook not registered | STOP with install instructions. |
 | Disk full during state write | STOP — state may be corrupted. Delete state file and restart. |
 | PR creation fails (auth/permission) | STOP — commit is safe on branch. User can manually create PR. |
@@ -662,7 +684,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 - PR_CREATED: PR exists (unless --no-pr)
 - REVIEWED: Review posted with verdict (unless --skip-review)
 - INCREMENTAL_REVIEW: Re-verify uses `--since-last-review` for token optimization
-- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues or MAX_CYCLES reached
+- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
+- NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -425,6 +425,16 @@ This will: detect toolchain, load artifact directly, fix issues by severity, val
 **DO NOT**: Manually read and fix issues yourself, run validation separately.
 **CHECKPOINT**: Did you invoke `{TOOL}:review-fix`? If not → STOP → invoke it.
 
+**Capture review-fix outcome** for Step 6.4:
+
+| review-fix result | Set |
+|-------------------|-----|
+| All issues fixed (skipped_count = 0) | `PENDING_SKIPPED = false` |
+| Some fixed, some skipped (skipped_count > 0) | `PENDING_SKIPPED = true`, `SKIPPED_COUNT = N` |
+| All issues skipped (fixed_count = 0, skipped_count > 0) | `PENDING_SKIPPED = true`, `ALL_SKIPPED = true` |
+
+**Zero-issues bar**: skipped issues are NOT resolved — they are deferred. Do not proceed to Step 7 as if done.
+
 #### 6.4 Re-verify
 
 Increment: `REVIEW_CYCLE += 1`
@@ -433,11 +443,22 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 **Re-verify always uses single-agent review** (`{TOOL}:review`) regardless of `REVIEW_SINGLE_AGENT` setting — multi-agent re-verify is wasteful for incremental changes.
 
-Use `{TOOL}:review` with `{PR_NUMBER} --since-last-review` for **incremental review** (only reviews changes since last review — saves tokens).
+**Re-verify mode depends on `PENDING_SKIPPED`:**
+
+| PENDING_SKIPPED | Re-verify command | Why |
+|-----------------|-------------------|-----|
+| `false` (all fixed) | `{TOOL}:review {PR_NUMBER} --since-last-review` (incremental) | Only new code changed — delta review saves tokens |
+| `true` (some/all skipped) | `{TOOL}:review {PR_NUMBER} --context` (FULL review) | Skipped items did NOT change code but STILL need to re-surface — incremental delta would miss them and produce false "0 issues" |
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
 → **Return to Step 6.2** to evaluate results.
+
+**Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
+- Do NOT loop another round — review-fix has no additional tooling to resolve these.
+- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Set `REVIEW_VERDICT = "needs_manual_fix"`.
+- Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 
 ---
 
@@ -633,7 +654,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 | State file exists but `--resume` not passed | Interactive: warn and ask. `--no-interact`: auto-delete stale state, start fresh. |
 | Lock file exists (concurrent run) | Check age — if >2 hours, treat as stale and remove. Otherwise STOP. |
 | Review finds no issues | Skip review-fix, proceed directly to summary. |
-| All review-fix issues skipped | Report skipped issues in summary. Still counts as "reviewed". |
+| All review-fix issues skipped (fixed_count=0) | Do NOT proceed to summary as "done". Set `ALL_SKIPPED = true` and follow Step 6.4 Escalation Guard: after round 2 with all-skipped, create escalation GH issue + set `REVIEW_VERDICT = needs_manual_fix` + skip merge. Zero-issues target is not satisfied by "we tried review-fix and it gave up". |
+| Some review-fix issues skipped | Re-verify with FULL review (`--context`, not `--since-last-review`) so skipped items re-surface in next 6.2 evaluation. See Step 6.4 table. |
 | `--ralph` but hook not registered | STOP with install instructions. |
 | Disk full during state write | STOP — state may be corrupted. Delete state file and restart. |
 | PR creation fails (auth/permission) | STOP — commit is safe on branch. User can manually create PR. |
@@ -658,7 +680,8 @@ State and lock files are only deleted here — after merge and cleanup succeed. 
 - PR_CREATED: PR exists (unless --no-pr)
 - REVIEWED: Review posted with verdict (unless --skip-review)
 - INCREMENTAL_REVIEW: Re-verify uses `--since-last-review` for token optimization
-- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues or MAX_CYCLES reached
+- ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
+- NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion


### PR DESCRIPTION
## Problem

`prp-run-all`'s stated `ZERO_ISSUES_TARGET` leaked through 2 paths, letting suggestion-severity issues pass into merged PRs:

### Leak 1 — Edge case "Still counts as 'reviewed'"

```
| All review-fix issues skipped | ... Still counts as "reviewed". |
```

Directly contradicted the stated goal. When review-fix skipped everything (common for items needing design judgment), workflow proceeded to merge as if review passed.

### Leak 2 — Re-verify using `--since-last-review` after skipped rounds

Step 6.4 always used incremental review. When review-fix skipped all, NO code changed → incremental saw empty delta → "0 issues" → loop exited with original issues still present.

## Evidence

From one recent session (2026-04-17, agent-psak), 5 merged PRs reviewer verdicts:

- PR #64: 2 suggestions ✗ merged
- PR #21: 1 suggestion ✗ merged  
- PR #63: 1 deferred suggestion ✗ merged
- PR #22: 0 all ✓
- PR #181: 0 all ✓

3 of 5 merged with suggestion-severity outstanding — exactly what `ZERO_ISSUES_TARGET` says shouldn't happen.

## Fix

### Step 6.3 — capture review-fix outcome
Track `PENDING_SKIPPED` / `ALL_SKIPPED` / `SKIPPED_COUNT`. Explicit: "skipped ≠ resolved".

### Step 6.4 — conditional re-verify mode

| PENDING_SKIPPED | Re-verify |
|---|---|
| false | `--since-last-review` incremental |
| true | `--context` FULL review (skipped items re-surface) |

### Step 6.4 — Escalation Guard (NEW)

If `ALL_SKIPPED = true` for 2 consecutive rounds → stop loop, create `[escalation]` GH issue, set `REVIEW_VERDICT = needs_manual_fix`, **do NOT merge**.

### Edge Cases — close Leak 1
Rewrote "All review-fix issues skipped" row to require escalation, not silent pass-through.

### Success Criteria — make the bar explicit
```
ZERO_ISSUES_TARGET: ...Skipped issues count as remaining — deferred, not resolved.
NO_SILENT_MERGE: --merge only executes when REVIEW_VERDICT = "0_issues".
```

## Regenerated 5 adapters

`scripts/generate-adapters.py` → 5 generated, 0 errors. All adapter files contain new markers:
- `adapters/claude-code/prp-run-all.md`
- `adapters/codex/prp-run-all/SKILL.md`
- `adapters/antigravity/prp-run-all.md`
- `adapters/gemini/run-all.toml`
- `adapters/opencode/run-all.md`

Verified: 5× `PENDING_SKIPPED` hits per file.

## Scope

6 files, +156/-18:
- `prompts/run-all.md` (source of truth, +40/-6 in Step 6 + Edge Cases + Success Criteria)
- 5 adapter outputs auto-regenerated

No changes to other commands, scripts, state-mgmt, or `adapters.yml`.

## Test plan

- [x] `generate-adapters.py` clean run
- [x] All 5 adapters contain new semantic markers
- [ ] Post-merge: next `prp-run-all` with suggestion-severity issues → loop until fixed OR escalation issue created (not silent merge)

## Related

- `~/.claude/CLAUDE.md` Post-Implement Hard Rule (2026-04-17) bans declaring done without 0 issues all severities. This PR fixes the framework leak undercutting that rule.
- Session retro: ψ/memory/retrospectives/2026-04/17/14.11_obsidian-stack-live-plus-hard-rules-deployed.md