### PR TITLE
fix(review-fix,run-all): follow-ups from PR #61 — Phase numbering + escalation labels

### DIFF
--- a/adapters/antigravity/prp-review-fix.md
+++ b/adapters/antigravity/prp-review-fix.md
@@ -678,7 +678,7 @@ Append a "Fix Outcome" section to the review artifact:
 
 ### Next Steps
 
-{If LOOP_MODE and all critical/high fixed:} "Entering Phase 7 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
+{If LOOP_MODE and all critical/high fixed:} "Entering Phase 10 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
 {If SINGLE_PASS and all critical/high fixed:} "Ready for re-review. Run `/prp-review {NUMBER}` to verify."
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
@@ -687,11 +687,13 @@ Append a "Fix Outcome" section to the review artifact:
 
 ---
 
-## Phase 7: LOOP — Re-review and Repeat (LOOP_MODE only)
+## Phase 10: LOOP — Re-review and Repeat (LOOP_MODE only)
 
 **SKIP this entire phase if `LOOP_MODE = false`** (i.e., `--severity` or `--single-pass` was explicit, OR this is a nested review-fix invocation from run-all).
 
-### 7.1 Decide Re-review Mode
+> **Numbering note:** the document already has Phase 7: PUSH, Phase 8: REPORT, and Phase 9: OUTPUT. The loop runs AFTER all of those as the final optional stage, so it is numbered Phase 10 to avoid collision. Earlier drafts used "Phase 7: LOOP" which collided with "Phase 7: PUSH" — fixed 2026-04-17.
+
+### 10.1 Decide Re-review Mode
 
 Track which issues review-fix just skipped vs actually fixed, and choose the re-review command accordingly (mirrors `run-all` Step 6.4, post PR #59):
 
@@ -701,14 +703,14 @@ Track which issues review-fix just skipped vs actually fixed, and choose the re-
 | Some issues skipped | `true`, `SKIPPED_COUNT = N` | `/prp-review {NUMBER} --context` (FULL review — skipped items need to re-surface, incremental would miss them) |
 | All issues skipped (no code change) | `true`, `ALL_SKIPPED = true` | `/prp-review {NUMBER} --context` (FULL review), then evaluate Escalation Guard below |
 
-### 7.2 Invoke Re-review
+### 10.2 Invoke Re-review
 
 Run the chosen review command. Wait for completion. Capture the new artifact path.
 
 **DO NOT**: Read the code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke `/prp-review`? If not → STOP → invoke it.
 
-### 7.3 Evaluate Result
+### 10.3 Evaluate Result
 
 Parse the new artifact for issues at the full default severity set (`critical,high,medium,suggestion` — the LOOP_MODE default; no user-provided filter applies here since LOOP_MODE implies no `--severity`):
 
@@ -716,9 +718,9 @@ Parse the new artifact for issues at the full default severity set (`critical,hi
 |--------|--------|
 | 0 issues (all severities) | Set `LOOP_VERDICT = "0_issues"`. Display `"All {ROUND} rounds converged on 0 issues — done."`. EXIT ✓. |
 | Issues found AND `ROUND < MAX_ROUNDS` | Increment `ROUND += 1`. Set ARTIFACT to the new path. **Return to Phase 1** with the new artifact, reusing `LOOP_MODE = true` and current `ROUND` value. |
-| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 7.4 Escalation. |
+| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 10.4 Escalation. |
 
-### 7.4 Escalation Guard
+### 10.4 Escalation Guard
 
 Triggers when either:
 - `ROUND >= MAX_ROUNDS` AND issues remain, OR
@@ -726,18 +728,26 @@ Triggers when either:
 
 On trigger:
 
-1. Create GH issue documenting the remaining items:
-   ```
+1. Create GH issue documenting the remaining items. Label strategy: the `[escalation]` prefix in the title carries the signal; add repo-appropriate labels only if they exist (graceful fallback avoids hard-fail on repos with different label schemes):
+   ```bash
+   # Build --label args only for labels that exist in this repo
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
    gh issue create \
      --title "[escalation] review-fix: {N} issues need human judgment on PR #{NUMBER}" \
-     --label "priority:P2-important,status:escalated" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
      --body "<summary of remaining issues + last review artifact path + round count + diagnosis>"
    ```
+   If all fallbacks miss (no recognized labels in the repo), `gh issue create` runs with NO `--label` flag — the issue is still created and the `[escalation]` title prefix makes it discoverable via search. Do NOT hard-fail the workflow on missing labels.
 2. Set `LOOP_VERDICT = "needs_manual_fix"`.
 3. Post PR comment summarizing the escalation with a link to the new issue.
 4. EXIT with clear message: `"{N} issues require human review after {ROUND} rounds. Escalation issue: <url>. Do NOT merge until resolved."`
 
-### 7.5 Loop Invariants
+### 10.5 Loop Invariants
 
 - Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
@@ -822,5 +832,5 @@ Note: passing `--severity` implicitly disables LOOP_MODE (see Input → Flag sem
 - PR_COMMENTED: Summary posted to GitHub
 - ARTIFACT_UPDATED: Review artifact has fix outcome appended
 - SUMMARY_SAVED: Fix summary saved with timestamp to `.prp-output/reviews/`
-- LOOP_CONVERGED (LOOP_MODE only): Phase 7 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
+- LOOP_CONVERGED (LOOP_MODE only): Phase 10 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
 - NO_SILENT_EXIT (LOOP_MODE only): If ALL_SKIPPED for 2 consecutive rounds OR MAX_ROUNDS exceeded, escalation GH issue exists. Matches `run-all` Step 6.4 guarantee.

--- a/adapters/antigravity/prp-review-fix.md
+++ b/adapters/antigravity/prp-review-fix.md
@@ -683,7 +683,7 @@ Append a "Fix Outcome" section to the review artifact:
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
 
-> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 7 loop (run-all's Step 6 is the outer loop).
+> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 10 loop (run-all's Step 6 is the outer loop).
 
 ---
 
@@ -749,7 +749,7 @@ On trigger:
 
 ### 10.5 Loop Invariants
 
-- Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
+- Phase 10 only runs after Phase 6 (commit) succeeds. If commit fails, the loop does not start. (Phases 7–9 — PUSH/REPORT/OUTPUT — run whether or not the loop triggers.)
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
 - `ROUND` counts distinct (review, fix) pairs. Round 1 is the initial review-fix invocation; round 2 is the first re-review + fix; etc.
 - `MAX_ROUNDS` defaults to 5 (via `--max-rounds`). The escalation-after-2-all-skipped guard is narrower and catches the "review-fix cannot make progress" case earlier.
@@ -793,7 +793,7 @@ If file content differs significantly from what review expected:
 All {N} issues were skipped (unclear fixes or validation failures).
 ```
 
-If `LOOP_MODE = true`: Phase 7.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
+If `LOOP_MODE = true`: Phase 10.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
 
 If `LOOP_MODE = false` (single-pass): Display "Manual review required. See skip log above." and exit normally.
 

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -459,7 +459,19 @@ If `--since-last-review` not supported or fails, fall back to full review with `
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.
-- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Create escalation GH issue with the remaining items. Label strategy: the `[escalation]` title prefix carries the signal — add repo-appropriate labels only if they exist in the target repo (graceful fallback so different repos with different label schemes do not hard-fail the workflow):
+   ```bash
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
+   gh issue create \
+     --title "[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
+     --body "<remaining-items summary + artifact path + round count>"
+   ```
 - Set `REVIEW_VERDICT = "needs_manual_fix"`.
 - Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 

--- a/adapters/claude-code/prp-review-fix.md
+++ b/adapters/claude-code/prp-review-fix.md
@@ -685,7 +685,7 @@ Append a "Fix Outcome" section to the review artifact:
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
 
-> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 7 loop (run-all's Step 6 is the outer loop).
+> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 10 loop (run-all's Step 6 is the outer loop).
 
 ---
 
@@ -751,7 +751,7 @@ On trigger:
 
 ### 10.5 Loop Invariants
 
-- Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
+- Phase 10 only runs after Phase 6 (commit) succeeds. If commit fails, the loop does not start. (Phases 7–9 — PUSH/REPORT/OUTPUT — run whether or not the loop triggers.)
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
 - `ROUND` counts distinct (review, fix) pairs. Round 1 is the initial review-fix invocation; round 2 is the first re-review + fix; etc.
 - `MAX_ROUNDS` defaults to 5 (via `--max-rounds`). The escalation-after-2-all-skipped guard is narrower and catches the "review-fix cannot make progress" case earlier.
@@ -795,7 +795,7 @@ If file content differs significantly from what review expected:
 All {N} issues were skipped (unclear fixes or validation failures).
 ```
 
-If `LOOP_MODE = true`: Phase 7.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
+If `LOOP_MODE = true`: Phase 10.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
 
 If `LOOP_MODE = false` (single-pass): Display "Manual review required. See skip log above." and exit normally.
 

--- a/adapters/claude-code/prp-review-fix.md
+++ b/adapters/claude-code/prp-review-fix.md
@@ -680,7 +680,7 @@ Append a "Fix Outcome" section to the review artifact:
 
 ### Next Steps
 
-{If LOOP_MODE and all critical/high fixed:} "Entering Phase 7 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
+{If LOOP_MODE and all critical/high fixed:} "Entering Phase 10 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
 {If SINGLE_PASS and all critical/high fixed:} "Ready for re-review. Run `/prp-core:prp-review {NUMBER}` to verify."
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
@@ -689,11 +689,13 @@ Append a "Fix Outcome" section to the review artifact:
 
 ---
 
-## Phase 7: LOOP — Re-review and Repeat (LOOP_MODE only)
+## Phase 10: LOOP — Re-review and Repeat (LOOP_MODE only)
 
 **SKIP this entire phase if `LOOP_MODE = false`** (i.e., `--severity` or `--single-pass` was explicit, OR this is a nested review-fix invocation from run-all).
 
-### 7.1 Decide Re-review Mode
+> **Numbering note:** the document already has Phase 7: PUSH, Phase 8: REPORT, and Phase 9: OUTPUT. The loop runs AFTER all of those as the final optional stage, so it is numbered Phase 10 to avoid collision. Earlier drafts used "Phase 7: LOOP" which collided with "Phase 7: PUSH" — fixed 2026-04-17.
+
+### 10.1 Decide Re-review Mode
 
 Track which issues review-fix just skipped vs actually fixed, and choose the re-review command accordingly (mirrors `run-all` Step 6.4, post PR #59):
 
@@ -703,14 +705,14 @@ Track which issues review-fix just skipped vs actually fixed, and choose the re-
 | Some issues skipped | `true`, `SKIPPED_COUNT = N` | `/prp-core:prp-review {NUMBER} --context` (FULL review — skipped items need to re-surface, incremental would miss them) |
 | All issues skipped (no code change) | `true`, `ALL_SKIPPED = true` | `/prp-core:prp-review {NUMBER} --context` (FULL review), then evaluate Escalation Guard below |
 
-### 7.2 Invoke Re-review
+### 10.2 Invoke Re-review
 
 Run the chosen review command. Wait for completion. Capture the new artifact path.
 
 **DO NOT**: Read the code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke `/prp-core:prp-review`? If not → STOP → invoke it.
 
-### 7.3 Evaluate Result
+### 10.3 Evaluate Result
 
 Parse the new artifact for issues at the full default severity set (`critical,high,medium,suggestion` — the LOOP_MODE default; no user-provided filter applies here since LOOP_MODE implies no `--severity`):
 
@@ -718,9 +720,9 @@ Parse the new artifact for issues at the full default severity set (`critical,hi
 |--------|--------|
 | 0 issues (all severities) | Set `LOOP_VERDICT = "0_issues"`. Display `"All {ROUND} rounds converged on 0 issues — done."`. EXIT ✓. |
 | Issues found AND `ROUND < MAX_ROUNDS` | Increment `ROUND += 1`. Set ARTIFACT to the new path. **Return to Phase 1** with the new artifact, reusing `LOOP_MODE = true` and current `ROUND` value. |
-| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 7.4 Escalation. |
+| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 10.4 Escalation. |
 
-### 7.4 Escalation Guard
+### 10.4 Escalation Guard
 
 Triggers when either:
 - `ROUND >= MAX_ROUNDS` AND issues remain, OR
@@ -728,18 +730,26 @@ Triggers when either:
 
 On trigger:
 
-1. Create GH issue documenting the remaining items:
-   ```
+1. Create GH issue documenting the remaining items. Label strategy: the `[escalation]` prefix in the title carries the signal; add repo-appropriate labels only if they exist (graceful fallback avoids hard-fail on repos with different label schemes):
+   ```bash
+   # Build --label args only for labels that exist in this repo
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
    gh issue create \
      --title "[escalation] review-fix: {N} issues need human judgment on PR #{NUMBER}" \
-     --label "priority:P2-important,status:escalated" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
      --body "<summary of remaining issues + last review artifact path + round count + diagnosis>"
    ```
+   If all fallbacks miss (no recognized labels in the repo), `gh issue create` runs with NO `--label` flag — the issue is still created and the `[escalation]` title prefix makes it discoverable via search. Do NOT hard-fail the workflow on missing labels.
 2. Set `LOOP_VERDICT = "needs_manual_fix"`.
 3. Post PR comment summarizing the escalation with a link to the new issue.
 4. EXIT with clear message: `"{N} issues require human review after {ROUND} rounds. Escalation issue: <url>. Do NOT merge until resolved."`
 
-### 7.5 Loop Invariants
+### 10.5 Loop Invariants
 
 - Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
@@ -824,7 +834,7 @@ Note: passing `--severity` implicitly disables LOOP_MODE (see Input → Flag sem
 - PR_COMMENTED: Summary posted to GitHub
 - ARTIFACT_UPDATED: Review artifact has fix outcome appended
 - SUMMARY_SAVED: Fix summary saved with timestamp to `.prp-output/reviews/`
-- LOOP_CONVERGED (LOOP_MODE only): Phase 7 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
+- LOOP_CONVERGED (LOOP_MODE only): Phase 10 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
 - NO_SILENT_EXIT (LOOP_MODE only): If ALL_SKIPPED for 2 consecutive rounds OR MAX_ROUNDS exceeded, escalation GH issue exists. Matches `run-all` Step 6.4 guarantee.
 
 </process>

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -461,7 +461,19 @@ If `--since-last-review` not supported or fails, fall back to full review with `
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.
-- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Create escalation GH issue with the remaining items. Label strategy: the `[escalation]` title prefix carries the signal — add repo-appropriate labels only if they exist in the target repo (graceful fallback so different repos with different label schemes do not hard-fail the workflow):
+   ```bash
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
+   gh issue create \
+     --title "[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
+     --body "<remaining-items summary + artifact path + round count>"
+   ```
 - Set `REVIEW_VERDICT = "needs_manual_fix"`.
 - Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 

--- a/adapters/codex/prp-review-fix/SKILL.md
+++ b/adapters/codex/prp-review-fix/SKILL.md
@@ -681,7 +681,7 @@ Append a "Fix Outcome" section to the review artifact:
 
 ### Next Steps
 
-{If LOOP_MODE and all critical/high fixed:} "Entering Phase 7 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
+{If LOOP_MODE and all critical/high fixed:} "Entering Phase 10 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
 {If SINGLE_PASS and all critical/high fixed:} "Ready for re-review. Run `$prp-review {NUMBER}` to verify."
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
@@ -690,11 +690,13 @@ Append a "Fix Outcome" section to the review artifact:
 
 ---
 
-## Phase 7: LOOP — Re-review and Repeat (LOOP_MODE only)
+## Phase 10: LOOP — Re-review and Repeat (LOOP_MODE only)
 
 **SKIP this entire phase if `LOOP_MODE = false`** (i.e., `--severity` or `--single-pass` was explicit, OR this is a nested review-fix invocation from run-all).
 
-### 7.1 Decide Re-review Mode
+> **Numbering note:** the document already has Phase 7: PUSH, Phase 8: REPORT, and Phase 9: OUTPUT. The loop runs AFTER all of those as the final optional stage, so it is numbered Phase 10 to avoid collision. Earlier drafts used "Phase 7: LOOP" which collided with "Phase 7: PUSH" — fixed 2026-04-17.
+
+### 10.1 Decide Re-review Mode
 
 Track which issues review-fix just skipped vs actually fixed, and choose the re-review command accordingly (mirrors `run-all` Step 6.4, post PR #59):
 
@@ -704,14 +706,14 @@ Track which issues review-fix just skipped vs actually fixed, and choose the re-
 | Some issues skipped | `true`, `SKIPPED_COUNT = N` | `$prp-review {NUMBER} --context` (FULL review — skipped items need to re-surface, incremental would miss them) |
 | All issues skipped (no code change) | `true`, `ALL_SKIPPED = true` | `$prp-review {NUMBER} --context` (FULL review), then evaluate Escalation Guard below |
 
-### 7.2 Invoke Re-review
+### 10.2 Invoke Re-review
 
 Run the chosen review command. Wait for completion. Capture the new artifact path.
 
 **DO NOT**: Read the code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke `$prp-review`? If not → STOP → invoke it.
 
-### 7.3 Evaluate Result
+### 10.3 Evaluate Result
 
 Parse the new artifact for issues at the full default severity set (`critical,high,medium,suggestion` — the LOOP_MODE default; no user-provided filter applies here since LOOP_MODE implies no `--severity`):
 
@@ -719,9 +721,9 @@ Parse the new artifact for issues at the full default severity set (`critical,hi
 |--------|--------|
 | 0 issues (all severities) | Set `LOOP_VERDICT = "0_issues"`. Display `"All {ROUND} rounds converged on 0 issues — done."`. EXIT ✓. |
 | Issues found AND `ROUND < MAX_ROUNDS` | Increment `ROUND += 1`. Set ARTIFACT to the new path. **Return to Phase 1** with the new artifact, reusing `LOOP_MODE = true` and current `ROUND` value. |
-| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 7.4 Escalation. |
+| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 10.4 Escalation. |
 
-### 7.4 Escalation Guard
+### 10.4 Escalation Guard
 
 Triggers when either:
 - `ROUND >= MAX_ROUNDS` AND issues remain, OR
@@ -729,18 +731,26 @@ Triggers when either:
 
 On trigger:
 
-1. Create GH issue documenting the remaining items:
-   ```
+1. Create GH issue documenting the remaining items. Label strategy: the `[escalation]` prefix in the title carries the signal; add repo-appropriate labels only if they exist (graceful fallback avoids hard-fail on repos with different label schemes):
+   ```bash
+   # Build --label args only for labels that exist in this repo
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
    gh issue create \
      --title "[escalation] review-fix: {N} issues need human judgment on PR #{NUMBER}" \
-     --label "priority:P2-important,status:escalated" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
      --body "<summary of remaining issues + last review artifact path + round count + diagnosis>"
    ```
+   If all fallbacks miss (no recognized labels in the repo), `gh issue create` runs with NO `--label` flag — the issue is still created and the `[escalation]` title prefix makes it discoverable via search. Do NOT hard-fail the workflow on missing labels.
 2. Set `LOOP_VERDICT = "needs_manual_fix"`.
 3. Post PR comment summarizing the escalation with a link to the new issue.
 4. EXIT with clear message: `"{N} issues require human review after {ROUND} rounds. Escalation issue: <url>. Do NOT merge until resolved."`
 
-### 7.5 Loop Invariants
+### 10.5 Loop Invariants
 
 - Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
@@ -825,5 +835,5 @@ $prp-review-fix .prp-output/reviews/pr-42-review-codex.md  # By artifact path, L
 - PR_COMMENTED: Summary posted to GitHub
 - ARTIFACT_UPDATED: Review artifact has fix outcome appended
 - SUMMARY_SAVED: Fix summary saved with timestamp to `.prp-output/reviews/`
-- LOOP_CONVERGED (LOOP_MODE only): Phase 7 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
+- LOOP_CONVERGED (LOOP_MODE only): Phase 10 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
 - NO_SILENT_EXIT (LOOP_MODE only): If ALL_SKIPPED for 2 consecutive rounds OR MAX_ROUNDS exceeded, escalation GH issue exists. Matches `run-all` Step 6.4 guarantee.

--- a/adapters/codex/prp-review-fix/SKILL.md
+++ b/adapters/codex/prp-review-fix/SKILL.md
@@ -686,7 +686,7 @@ Append a "Fix Outcome" section to the review artifact:
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
 
-> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 7 loop (run-all's Step 6 is the outer loop).
+> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 10 loop (run-all's Step 6 is the outer loop).
 
 ---
 
@@ -752,7 +752,7 @@ On trigger:
 
 ### 10.5 Loop Invariants
 
-- Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
+- Phase 10 only runs after Phase 6 (commit) succeeds. If commit fails, the loop does not start. (Phases 7–9 — PUSH/REPORT/OUTPUT — run whether or not the loop triggers.)
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
 - `ROUND` counts distinct (review, fix) pairs. Round 1 is the initial review-fix invocation; round 2 is the first re-review + fix; etc.
 - `MAX_ROUNDS` defaults to 5 (via `--max-rounds`). The escalation-after-2-all-skipped guard is narrower and catches the "review-fix cannot make progress" case earlier.
@@ -796,7 +796,7 @@ If file content differs significantly from what review expected:
 All {N} issues were skipped (unclear fixes or validation failures).
 ```
 
-If `LOOP_MODE = true`: Phase 7.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
+If `LOOP_MODE = true`: Phase 10.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
 
 If `LOOP_MODE = false` (single-pass): Display "Manual review required. See skip log above." and exit normally.
 

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -462,7 +462,19 @@ If `--since-last-review` not supported or fails, fall back to full review with `
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.
-- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Create escalation GH issue with the remaining items. Label strategy: the `[escalation]` title prefix carries the signal — add repo-appropriate labels only if they exist in the target repo (graceful fallback so different repos with different label schemes do not hard-fail the workflow):
+   ```bash
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
+   gh issue create \
+     --title "[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
+     --body "<remaining-items summary + artifact path + round count>"
+   ```
 - Set `REVIEW_VERDICT = "needs_manual_fix"`.
 - Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 

--- a/adapters/gemini/review-fix.toml
+++ b/adapters/gemini/review-fix.toml
@@ -677,7 +677,7 @@ Append a "Fix Outcome" section to the review artifact:
 
 ### Next Steps
 
-{If LOOP_MODE and all critical/high fixed:} "Entering Phase 7 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
+{If LOOP_MODE and all critical/high fixed:} "Entering Phase 10 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
 {If SINGLE_PASS and all critical/high fixed:} "Ready for re-review. Run `/review {NUMBER}` to verify."
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
@@ -686,11 +686,13 @@ Append a "Fix Outcome" section to the review artifact:
 
 ---
 
-## Phase 7: LOOP — Re-review and Repeat (LOOP_MODE only)
+## Phase 10: LOOP — Re-review and Repeat (LOOP_MODE only)
 
 **SKIP this entire phase if `LOOP_MODE = false`** (i.e., `--severity` or `--single-pass` was explicit, OR this is a nested review-fix invocation from run-all).
 
-### 7.1 Decide Re-review Mode
+> **Numbering note:** the document already has Phase 7: PUSH, Phase 8: REPORT, and Phase 9: OUTPUT. The loop runs AFTER all of those as the final optional stage, so it is numbered Phase 10 to avoid collision. Earlier drafts used "Phase 7: LOOP" which collided with "Phase 7: PUSH" — fixed 2026-04-17.
+
+### 10.1 Decide Re-review Mode
 
 Track which issues review-fix just skipped vs actually fixed, and choose the re-review command accordingly (mirrors `run-all` Step 6.4, post PR #59):
 
@@ -700,14 +702,14 @@ Track which issues review-fix just skipped vs actually fixed, and choose the re-
 | Some issues skipped | `true`, `SKIPPED_COUNT = N` | `/review {NUMBER} --context` (FULL review — skipped items need to re-surface, incremental would miss them) |
 | All issues skipped (no code change) | `true`, `ALL_SKIPPED = true` | `/review {NUMBER} --context` (FULL review), then evaluate Escalation Guard below |
 
-### 7.2 Invoke Re-review
+### 10.2 Invoke Re-review
 
 Run the chosen review command. Wait for completion. Capture the new artifact path.
 
 **DO NOT**: Read the code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke `/review`? If not → STOP → invoke it.
 
-### 7.3 Evaluate Result
+### 10.3 Evaluate Result
 
 Parse the new artifact for issues at the full default severity set (`critical,high,medium,suggestion` — the LOOP_MODE default; no user-provided filter applies here since LOOP_MODE implies no `--severity`):
 
@@ -715,9 +717,9 @@ Parse the new artifact for issues at the full default severity set (`critical,hi
 |--------|--------|
 | 0 issues (all severities) | Set `LOOP_VERDICT = "0_issues"`. Display `"All {ROUND} rounds converged on 0 issues — done."`. EXIT ✓. |
 | Issues found AND `ROUND < MAX_ROUNDS` | Increment `ROUND += 1`. Set ARTIFACT to the new path. **Return to Phase 1** with the new artifact, reusing `LOOP_MODE = true` and current `ROUND` value. |
-| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 7.4 Escalation. |
+| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 10.4 Escalation. |
 
-### 7.4 Escalation Guard
+### 10.4 Escalation Guard
 
 Triggers when either:
 - `ROUND >= MAX_ROUNDS` AND issues remain, OR
@@ -725,18 +727,26 @@ Triggers when either:
 
 On trigger:
 
-1. Create GH issue documenting the remaining items:
-   ```
+1. Create GH issue documenting the remaining items. Label strategy: the `[escalation]` prefix in the title carries the signal; add repo-appropriate labels only if they exist (graceful fallback avoids hard-fail on repos with different label schemes):
+   ```bash
+   # Build --label args only for labels that exist in this repo
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\\"$LABEL\\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
    gh issue create \\
      --title "[escalation] review-fix: {N} issues need human judgment on PR #{NUMBER}" \\
-     --label "priority:P2-important,status:escalated" \\
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \\
      --body "<summary of remaining issues + last review artifact path + round count + diagnosis>"
    ```
+   If all fallbacks miss (no recognized labels in the repo), `gh issue create` runs with NO `--label` flag — the issue is still created and the `[escalation]` title prefix makes it discoverable via search. Do NOT hard-fail the workflow on missing labels.
 2. Set `LOOP_VERDICT = "needs_manual_fix"`.
 3. Post PR comment summarizing the escalation with a link to the new issue.
 4. EXIT with clear message: `"{N} issues require human review after {ROUND} rounds. Escalation issue: <url>. Do NOT merge until resolved."`
 
-### 7.5 Loop Invariants
+### 10.5 Loop Invariants
 
 - Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
@@ -821,7 +831,7 @@ Note: passing `--severity` implicitly disables LOOP_MODE (see Input → Flag sem
 - PR_COMMENTED: Summary posted to GitHub
 - ARTIFACT_UPDATED: Review artifact has fix outcome appended
 - SUMMARY_SAVED: Fix summary saved with timestamp to `.prp-output/reviews/`
-- LOOP_CONVERGED (LOOP_MODE only): Phase 7 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
+- LOOP_CONVERGED (LOOP_MODE only): Phase 10 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
 - NO_SILENT_EXIT (LOOP_MODE only): If ALL_SKIPPED for 2 consecutive rounds OR MAX_ROUNDS exceeded, escalation GH issue exists. Matches `run-all` Step 6.4 guarantee.
 
 """

--- a/adapters/gemini/review-fix.toml
+++ b/adapters/gemini/review-fix.toml
@@ -682,7 +682,7 @@ Append a "Fix Outcome" section to the review artifact:
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
 
-> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 7 loop (run-all's Step 6 is the outer loop).
+> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 10 loop (run-all's Step 6 is the outer loop).
 
 ---
 
@@ -748,7 +748,7 @@ On trigger:
 
 ### 10.5 Loop Invariants
 
-- Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
+- Phase 10 only runs after Phase 6 (commit) succeeds. If commit fails, the loop does not start. (Phases 7–9 — PUSH/REPORT/OUTPUT — run whether or not the loop triggers.)
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
 - `ROUND` counts distinct (review, fix) pairs. Round 1 is the initial review-fix invocation; round 2 is the first re-review + fix; etc.
 - `MAX_ROUNDS` defaults to 5 (via `--max-rounds`). The escalation-after-2-all-skipped guard is narrower and catches the "review-fix cannot make progress" case earlier.
@@ -792,7 +792,7 @@ If file content differs significantly from what review expected:
 All {N} issues were skipped (unclear fixes or validation failures).
 ```
 
-If `LOOP_MODE = true`: Phase 7.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
+If `LOOP_MODE = true`: Phase 10.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
 
 If `LOOP_MODE = false` (single-pass): Display "Manual review required. See skip log above." and exit normally.
 

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -458,7 +458,19 @@ If `--since-last-review` not supported or fails, fall back to full review with `
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.
-- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Create escalation GH issue with the remaining items. Label strategy: the `[escalation]` title prefix carries the signal — add repo-appropriate labels only if they exist in the target repo (graceful fallback so different repos with different label schemes do not hard-fail the workflow):
+   ```bash
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\\"$LABEL\\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
+   gh issue create \\
+     --title "[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}" \\
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \\
+     --body "<remaining-items summary + artifact path + round count>"
+   ```
 - Set `REVIEW_VERDICT = "needs_manual_fix"`.
 - Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 

--- a/adapters/opencode/review-fix.md
+++ b/adapters/opencode/review-fix.md
@@ -684,7 +684,7 @@ Append a "Fix Outcome" section to the review artifact:
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
 
-> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 7 loop (run-all's Step 6 is the outer loop).
+> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 10 loop (run-all's Step 6 is the outer loop).
 
 ---
 
@@ -750,7 +750,7 @@ On trigger:
 
 ### 10.5 Loop Invariants
 
-- Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
+- Phase 10 only runs after Phase 6 (commit) succeeds. If commit fails, the loop does not start. (Phases 7–9 — PUSH/REPORT/OUTPUT — run whether or not the loop triggers.)
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
 - `ROUND` counts distinct (review, fix) pairs. Round 1 is the initial review-fix invocation; round 2 is the first re-review + fix; etc.
 - `MAX_ROUNDS` defaults to 5 (via `--max-rounds`). The escalation-after-2-all-skipped guard is narrower and catches the "review-fix cannot make progress" case earlier.
@@ -794,7 +794,7 @@ If file content differs significantly from what review expected:
 All {N} issues were skipped (unclear fixes or validation failures).
 ```
 
-If `LOOP_MODE = true`: Phase 7.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
+If `LOOP_MODE = true`: Phase 10.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
 
 If `LOOP_MODE = false` (single-pass): Display "Manual review required. See skip log above." and exit normally.
 

--- a/adapters/opencode/review-fix.md
+++ b/adapters/opencode/review-fix.md
@@ -679,7 +679,7 @@ Append a "Fix Outcome" section to the review artifact:
 
 ### Next Steps
 
-{If LOOP_MODE and all critical/high fixed:} "Entering Phase 7 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
+{If LOOP_MODE and all critical/high fixed:} "Entering Phase 10 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
 {If SINGLE_PASS and all critical/high fixed:} "Ready for re-review. Run `/prp:review {NUMBER}` to verify."
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
@@ -688,11 +688,13 @@ Append a "Fix Outcome" section to the review artifact:
 
 ---
 
-## Phase 7: LOOP — Re-review and Repeat (LOOP_MODE only)
+## Phase 10: LOOP — Re-review and Repeat (LOOP_MODE only)
 
 **SKIP this entire phase if `LOOP_MODE = false`** (i.e., `--severity` or `--single-pass` was explicit, OR this is a nested review-fix invocation from run-all).
 
-### 7.1 Decide Re-review Mode
+> **Numbering note:** the document already has Phase 7: PUSH, Phase 8: REPORT, and Phase 9: OUTPUT. The loop runs AFTER all of those as the final optional stage, so it is numbered Phase 10 to avoid collision. Earlier drafts used "Phase 7: LOOP" which collided with "Phase 7: PUSH" — fixed 2026-04-17.
+
+### 10.1 Decide Re-review Mode
 
 Track which issues review-fix just skipped vs actually fixed, and choose the re-review command accordingly (mirrors `run-all` Step 6.4, post PR #59):
 
@@ -702,14 +704,14 @@ Track which issues review-fix just skipped vs actually fixed, and choose the re-
 | Some issues skipped | `true`, `SKIPPED_COUNT = N` | `/prp:review {NUMBER} --context` (FULL review — skipped items need to re-surface, incremental would miss them) |
 | All issues skipped (no code change) | `true`, `ALL_SKIPPED = true` | `/prp:review {NUMBER} --context` (FULL review), then evaluate Escalation Guard below |
 
-### 7.2 Invoke Re-review
+### 10.2 Invoke Re-review
 
 Run the chosen review command. Wait for completion. Capture the new artifact path.
 
 **DO NOT**: Read the code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke `/prp:review`? If not → STOP → invoke it.
 
-### 7.3 Evaluate Result
+### 10.3 Evaluate Result
 
 Parse the new artifact for issues at the full default severity set (`critical,high,medium,suggestion` — the LOOP_MODE default; no user-provided filter applies here since LOOP_MODE implies no `--severity`):
 
@@ -717,9 +719,9 @@ Parse the new artifact for issues at the full default severity set (`critical,hi
 |--------|--------|
 | 0 issues (all severities) | Set `LOOP_VERDICT = "0_issues"`. Display `"All {ROUND} rounds converged on 0 issues — done."`. EXIT ✓. |
 | Issues found AND `ROUND < MAX_ROUNDS` | Increment `ROUND += 1`. Set ARTIFACT to the new path. **Return to Phase 1** with the new artifact, reusing `LOOP_MODE = true` and current `ROUND` value. |
-| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 7.4 Escalation. |
+| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 10.4 Escalation. |
 
-### 7.4 Escalation Guard
+### 10.4 Escalation Guard
 
 Triggers when either:
 - `ROUND >= MAX_ROUNDS` AND issues remain, OR
@@ -727,18 +729,26 @@ Triggers when either:
 
 On trigger:
 
-1. Create GH issue documenting the remaining items:
-   ```
+1. Create GH issue documenting the remaining items. Label strategy: the `[escalation]` prefix in the title carries the signal; add repo-appropriate labels only if they exist (graceful fallback avoids hard-fail on repos with different label schemes):
+   ```bash
+   # Build --label args only for labels that exist in this repo
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
    gh issue create \
      --title "[escalation] review-fix: {N} issues need human judgment on PR #{NUMBER}" \
-     --label "priority:P2-important,status:escalated" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
      --body "<summary of remaining issues + last review artifact path + round count + diagnosis>"
    ```
+   If all fallbacks miss (no recognized labels in the repo), `gh issue create` runs with NO `--label` flag — the issue is still created and the `[escalation]` title prefix makes it discoverable via search. Do NOT hard-fail the workflow on missing labels.
 2. Set `LOOP_VERDICT = "needs_manual_fix"`.
 3. Post PR comment summarizing the escalation with a link to the new issue.
 4. EXIT with clear message: `"{N} issues require human review after {ROUND} rounds. Escalation issue: <url>. Do NOT merge until resolved."`
 
-### 7.5 Loop Invariants
+### 10.5 Loop Invariants
 
 - Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
@@ -823,5 +833,5 @@ Note: passing `--severity` implicitly disables LOOP_MODE (see Input → Flag sem
 - PR_COMMENTED: Summary posted to GitHub
 - ARTIFACT_UPDATED: Review artifact has fix outcome appended
 - SUMMARY_SAVED: Fix summary saved with timestamp to `.prp-output/reviews/`
-- LOOP_CONVERGED (LOOP_MODE only): Phase 7 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
+- LOOP_CONVERGED (LOOP_MODE only): Phase 10 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
 - NO_SILENT_EXIT (LOOP_MODE only): If ALL_SKIPPED for 2 consecutive rounds OR MAX_ROUNDS exceeded, escalation GH issue exists. Matches `run-all` Step 6.4 guarantee.

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -460,7 +460,19 @@ If `--since-last-review` not supported or fails, fall back to full review with `
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.
-- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Create escalation GH issue with the remaining items. Label strategy: the `[escalation]` title prefix carries the signal — add repo-appropriate labels only if they exist in the target repo (graceful fallback so different repos with different label schemes do not hard-fail the workflow):
+   ```bash
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
+   gh issue create \
+     --title "[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
+     --body "<remaining-items summary + artifact path + round count>"
+   ```
 - Set `REVIEW_VERDICT = "needs_manual_fix"`.
 - Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 

--- a/prompts/review-fix.md
+++ b/prompts/review-fix.md
@@ -675,7 +675,7 @@ Append a "Fix Outcome" section to the review artifact:
 
 ### Next Steps
 
-{If LOOP_MODE and all critical/high fixed:} "Entering Phase 7 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
+{If LOOP_MODE and all critical/high fixed:} "Entering Phase 10 re-review loop (round {ROUND}/{MAX_ROUNDS})..."
 {If SINGLE_PASS and all critical/high fixed:} "Ready for re-review. Run `{TOOL}:review {NUMBER}` to verify."
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
@@ -684,11 +684,13 @@ Append a "Fix Outcome" section to the review artifact:
 
 ---
 
-## Phase 7: LOOP — Re-review and Repeat (LOOP_MODE only)
+## Phase 10: LOOP — Re-review and Repeat (LOOP_MODE only)
 
 **SKIP this entire phase if `LOOP_MODE = false`** (i.e., `--severity` or `--single-pass` was explicit, OR this is a nested review-fix invocation from run-all).
 
-### 7.1 Decide Re-review Mode
+> **Numbering note:** the document already has Phase 7: PUSH, Phase 8: REPORT, and Phase 9: OUTPUT. The loop runs AFTER all of those as the final optional stage, so it is numbered Phase 10 to avoid collision. Earlier drafts used "Phase 7: LOOP" which collided with "Phase 7: PUSH" — fixed 2026-04-17.
+
+### 10.1 Decide Re-review Mode
 
 Track which issues review-fix just skipped vs actually fixed, and choose the re-review command accordingly (mirrors `run-all` Step 6.4, post PR #59):
 
@@ -698,14 +700,14 @@ Track which issues review-fix just skipped vs actually fixed, and choose the re-
 | Some issues skipped | `true`, `SKIPPED_COUNT = N` | `{TOOL}:review {NUMBER} --context` (FULL review — skipped items need to re-surface, incremental would miss them) |
 | All issues skipped (no code change) | `true`, `ALL_SKIPPED = true` | `{TOOL}:review {NUMBER} --context` (FULL review), then evaluate Escalation Guard below |
 
-### 7.2 Invoke Re-review
+### 10.2 Invoke Re-review
 
 Run the chosen review command. Wait for completion. Capture the new artifact path.
 
 **DO NOT**: Read the code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke `{TOOL}:review`? If not → STOP → invoke it.
 
-### 7.3 Evaluate Result
+### 10.3 Evaluate Result
 
 Parse the new artifact for issues at the full default severity set (`critical,high,medium,suggestion` — the LOOP_MODE default; no user-provided filter applies here since LOOP_MODE implies no `--severity`):
 
@@ -713,9 +715,9 @@ Parse the new artifact for issues at the full default severity set (`critical,hi
 |--------|--------|
 | 0 issues (all severities) | Set `LOOP_VERDICT = "0_issues"`. Display `"All {ROUND} rounds converged on 0 issues — done."`. EXIT ✓. |
 | Issues found AND `ROUND < MAX_ROUNDS` | Increment `ROUND += 1`. Set ARTIFACT to the new path. **Return to Phase 1** with the new artifact, reusing `LOOP_MODE = true` and current `ROUND` value. |
-| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 7.4 Escalation. |
+| Issues found AND `ROUND >= MAX_ROUNDS` | Go to 10.4 Escalation. |
 
-### 7.4 Escalation Guard
+### 10.4 Escalation Guard
 
 Triggers when either:
 - `ROUND >= MAX_ROUNDS` AND issues remain, OR
@@ -723,18 +725,26 @@ Triggers when either:
 
 On trigger:
 
-1. Create GH issue documenting the remaining items:
-   ```
+1. Create GH issue documenting the remaining items. Label strategy: the `[escalation]` prefix in the title carries the signal; add repo-appropriate labels only if they exist (graceful fallback avoids hard-fail on repos with different label schemes):
+   ```bash
+   # Build --label args only for labels that exist in this repo
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
    gh issue create \
      --title "[escalation] review-fix: {N} issues need human judgment on PR #{NUMBER}" \
-     --label "priority:P2-important,status:escalated" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
      --body "<summary of remaining issues + last review artifact path + round count + diagnosis>"
    ```
+   If all fallbacks miss (no recognized labels in the repo), `gh issue create` runs with NO `--label` flag — the issue is still created and the `[escalation]` title prefix makes it discoverable via search. Do NOT hard-fail the workflow on missing labels.
 2. Set `LOOP_VERDICT = "needs_manual_fix"`.
 3. Post PR comment summarizing the escalation with a link to the new issue.
 4. EXIT with clear message: `"{N} issues require human review after {ROUND} rounds. Escalation issue: <url>. Do NOT merge until resolved."`
 
-### 7.5 Loop Invariants
+### 10.5 Loop Invariants
 
 - Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
@@ -819,5 +829,5 @@ Note: passing `--severity` implicitly disables LOOP_MODE (see Input → Flag sem
 - PR_COMMENTED: Summary posted to GitHub
 - ARTIFACT_UPDATED: Review artifact has fix outcome appended
 - SUMMARY_SAVED: Fix summary saved with timestamp to `.prp-output/reviews/`
-- LOOP_CONVERGED (LOOP_MODE only): Phase 7 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
+- LOOP_CONVERGED (LOOP_MODE only): Phase 10 re-review loop exited with `LOOP_VERDICT = "0_issues"` OR `"needs_manual_fix"` (escalation issue created). Never exit LOOP_MODE silently with issues remaining and no escalation.
 - NO_SILENT_EXIT (LOOP_MODE only): If ALL_SKIPPED for 2 consecutive rounds OR MAX_ROUNDS exceeded, escalation GH issue exists. Matches `run-all` Step 6.4 guarantee.

--- a/prompts/review-fix.md
+++ b/prompts/review-fix.md
@@ -680,7 +680,7 @@ Append a "Fix Outcome" section to the review artifact:
 {If critical still open:} "{N} critical issues require manual attention before merge."
 ```
 
-> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 7 loop (run-all's Step 6 is the outer loop).
+> **Note for orchestrators**: The "Next Steps" above are for standalone usage only. If this command was invoked as part of run-all, the orchestrator should ignore these suggestions and proceed to its next step. Also: orchestrators should pass `--single-pass` to prevent review-fix from launching its own Phase 10 loop (run-all's Step 6 is the outer loop).
 
 ---
 
@@ -746,7 +746,7 @@ On trigger:
 
 ### 10.5 Loop Invariants
 
-- Phase 7 only runs after Phase 6 (commit) succeeds. If commit fails, loop does not start.
+- Phase 10 only runs after Phase 6 (commit) succeeds. If commit fails, the loop does not start. (Phases 7–9 — PUSH/REPORT/OUTPUT — run whether or not the loop triggers.)
 - Each loop iteration runs Phases 1 → 6 in full for the new artifact. This is the existing single-pass pipeline, re-entered with a fresh artifact.
 - `ROUND` counts distinct (review, fix) pairs. Round 1 is the initial review-fix invocation; round 2 is the first re-review + fix; etc.
 - `MAX_ROUNDS` defaults to 5 (via `--max-rounds`). The escalation-after-2-all-skipped guard is narrower and catches the "review-fix cannot make progress" case earlier.
@@ -790,7 +790,7 @@ If file content differs significantly from what review expected:
 All {N} issues were skipped (unclear fixes or validation failures).
 ```
 
-If `LOOP_MODE = true`: Phase 7.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
+If `LOOP_MODE = true`: Phase 10.4 Escalation Guard triggers after 2 consecutive all-skipped rounds — creates a tracked GH issue and exits. Do NOT silently return to caller as if done.
 
 If `LOOP_MODE = false` (single-pass): Display "Manual review required. See skip log above." and exit normally.
 

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -456,7 +456,19 @@ If `--since-last-review` not supported or fails, fall back to full review with `
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., we've run review-fix twice and it skipped everything both rounds), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.
-- Create escalation GH issue with the remaining items (title: `[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}`, labels: `priority:P2-important` + `status:escalated`).
+- Create escalation GH issue with the remaining items. Label strategy: the `[escalation]` title prefix carries the signal — add repo-appropriate labels only if they exist in the target repo (graceful fallback so different repos with different label schemes do not hard-fail the workflow):
+   ```bash
+   LABEL_ARGS=""
+   for LABEL in "priority:P2" "bug" "help wanted"; do
+     if gh label list -R "${REPO}" --json name -q ".[] | select(.name==\"$LABEL\") | .name" | grep -q .; then
+       LABEL_ARGS="${LABEL_ARGS:+$LABEL_ARGS,}$LABEL"
+     fi
+   done
+   gh issue create \
+     --title "[escalation] prp-run-all: {SKIPPED_COUNT} issues need human judgment on PR #{PR_NUMBER}" \
+     ${LABEL_ARGS:+--label "$LABEL_ARGS"} \
+     --body "<remaining-items summary + artifact path + round count>"
+   ```
 - Set `REVIEW_VERDICT = "needs_manual_fix"`.
 - Proceed to Step 7 SUMMARY, do NOT merge (even with `--merge`).
 


### PR DESCRIPTION
## Addresses 2 of 3 deferred items from PR #61 review

### 1. Phase 7 heading collision in review-fix.md
`Phase 7: PUSH` (existing) + `Phase 7: LOOP` (added by #61) = ambiguous parse. **Renumbered LOOP → Phase 10** (after 8/REPORT + 9/OUTPUT). Updated 5 subsection headers (10.1–10.5) + 2 cross-refs. All 5 adapters regenerated.

Verified: each review-fix adapter now has exactly 1× Phase 7, 1× Phase 10 — no collision.

### 2. Escalation labels hardcoded to non-existent values
Both `run-all.md` Step 6.4 and `review-fix.md` Phase 10.4 used:
```
--label "priority:P2-important,status:escalated"
```
Neither exists in `gobikom/prp-framework` (only priority:P0/P1/P2/P3). `gh issue create` would hard-fail on escalation path — silently breaking the safe-exit the Escalation Guard is supposed to provide.

**Fix**: graceful label selection — query `gh label list` for preferred labels (`priority:P2`, `bug`, `help wanted`) in priority order, include only those that exist. If all miss → run `gh issue create` with no `--label` flag at all. `[escalation]` title prefix remains canonical signal. Never hard-fail on label availability.

Applied to BOTH `prompts/run-all.md` Step 6.4 (from #59) and `prompts/review-fix.md` Phase 10.4 (from #61).

## Not included: item 3

"ALL_SKIPPED consecutive counter" — approximation (`REVIEW_CYCLE >= 2 AND ALL_SKIPPED`) works in practice; tightening requires state-file schema change. Tracked at #60.

## Scope

12 files, +210/-78:
- `prompts/run-all.md` (+14/-1) — Step 6.4 graceful label block
- `prompts/review-fix.md` (+21/-13) — Phase 7→10 rename + graceful labels + 2 cross-refs
- 10 adapter outputs regenerated

Generator: `10 generated, 0 errors`.

## Test plan

- [x] Generator clean
- [x] review-fix adapters: 1× Phase 7 + 1× Phase 10 each (verified)
- [x] Zero `priority:P2-important` / `status:escalated` in actively-invoked commands
- [ ] Post-merge: trigger escalation in test PR → works in prp-framework (label-less fallback), agent-devops (picks priority:P2-important if script expanded), any random repo (still creates issue)

## Related

- PR #59 (merged) — run-all zero-issues; introduced label bug
- PR #61 (merged) — review-fix loop mode; introduced Phase 7 collision
- #60 — state.sh follow-ups (remaining)