### PR TITLE
docs(run-all): mention safe-merge as optional alternative to gh pr merge

### DIFF
--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -559,6 +559,8 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+
 | Result | Action |
 |--------|--------|
 | Merged successfully | Proceed to 8.2 |

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -561,6 +561,8 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+
 | Result | Action |
 |--------|--------|
 | Merged successfully | Proceed to 8.2 |

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -562,6 +562,8 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+
 | Result | Action |
 |--------|--------|
 | Merged successfully | Proceed to 8.2 |

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -558,6 +558,8 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+
 | Result | Action |
 |--------|--------|
 | Merged successfully | Proceed to 8.2 |

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -560,6 +560,8 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+
 | Result | Action |
 |--------|--------|
 | Merged successfully | Proceed to 8.2 |

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -556,6 +556,8 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+
 | Result | Action |
 |--------|--------|
 | Merged successfully | Proceed to 8.2 |


### PR DESCRIPTION
## Summary

Non-breaking tip note added to Step 8.1 Merge in `prompts/run-all.md`. Regenerated to 5 adapters via \`scripts/generate-adapters.py\`.

## What Changes

| File | Change |
|---|---|
| \`prompts/run-all.md\` | +2 lines (source of truth) |
| \`adapters/antigravity/prp-run-all.md\` | +2 lines (regenerated) |
| \`adapters/claude-code/prp-run-all.md\` | +2 lines (regenerated) |
| \`adapters/codex/prp-run-all/SKILL.md\` | +2 lines (regenerated) |
| \`adapters/gemini/run-all.toml\` | +2 lines (regenerated) |
| \`adapters/opencode/run-all.md\` | +2 lines (regenerated) |

Total: 6 files, 12 insertions. No deletions, no other modifications.

## Why

prp-framework is distributed cross-tool and used by other workspaces. Hardcoding \`safe-merge\` would break anyone without it installed. A tip note is non-invasive — default \`gh pr merge\` command stays for everyone, and agents on workspaces with \`safe-merge\` see the hint.

Context: \`safe-merge\` is a GitHub-Pro-free workaround for server-side branch protection on private user repos. Shipped at \`gobikom/ops#10\` (merged 2026-04-19). See also agent-devops#71 (closed with Level B resolution).

## Review

Single-agent review (escape hatch: docs-only addition, no behavior change, mechanical regeneration from source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)