### PR TITLE
docs(run-all): update safe-merge tip — default-on cleanup + --no-cleanup

### DIFF
--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -559,7 +559,7 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -561,7 +561,7 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -562,7 +562,7 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -558,7 +558,7 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -560,7 +560,7 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
 
 | Result | Action |
 |--------|--------|

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -556,7 +556,7 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 gh pr merge {PR_NUMBER} --squash --delete-branch
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN) and an audit log, useful on private repos where server-side branch protection is not available. It accepts all the same flags. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
 
 | Result | Action |
 |--------|--------|


### PR DESCRIPTION
Single-line update to `prompts/run-all.md` mentioning default-on cleanup (added in gobikom/ops#11, merged) + the `--no-cleanup` opt-out flag. Regenerated 5 adapters via `scripts/generate-adapters.py` (5 generated, 140 unchanged).

Single-agent review (docs escape hatch, no behavior change for users without safe-merge).