### PR TITLE
fix(gen-ai-context): reverse scan for stale backup entries in --check

### DIFF
--- a/scripts/gen-ai-context.sh
+++ b/scripts/gen-ai-context.sh
@@ -426,6 +426,16 @@ do_check() {
                 fi
             fi
         done
+
+        # Reverse scan: warn about Context Map entries pointing at backup/stale dirs
+        while IFS= read -r entry; do
+            case "$entry" in
+                *.backup|*.backup.*|*.bak|*.old|*.orig|*~|*-backup|backup)
+                    log_warn "Context Map entry '$entry/' matches backup-dir skip pattern — run --update to remove"
+                    stale=1
+                    ;;
+            esac
+        done < <(grep -oE '`[^`]+/`' "$PROJECT_MD" 2>/dev/null | tr -d '`' | sed 's|/$||')
     fi
 
     # Summary

--- a/scripts/gen-ai-context.sh
+++ b/scripts/gen-ai-context.sh
@@ -187,7 +187,7 @@ generate_context_map() {
         dir="${dir%/}"
         # Skip common non-code dirs
         case "$dir" in
-            node_modules|.git|.prp|.prp-output|.claude|.codex|.opencode|.gemini|.agents|dist|build|__pycache__|.venv|venv|.env|coverage|.nyc_output|logs|output|tmp|temp|backup) continue ;;
+            node_modules|.git|.prp|.prp-output|.claude|.codex|.opencode|.gemini|.agents|dist|build|__pycache__|.venv|venv|.env|coverage|.nyc_output|logs|output|tmp|temp|backup|old) continue ;;
             src|test|tests|docs|scripts|bin|deploy|config|conf|prisma|public|static|assets) continue ;;  # already handled above
             *.backup|*.backup.*|*.bak|*.old|*.orig|*~|*-backup) continue ;;  # backup/stale dir conventions (#72)
         esac
@@ -416,7 +416,7 @@ do_check() {
         for dir in */; do
             dir="${dir%/}"
             case "$dir" in
-                node_modules|.git|.prp|.prp-output|.claude|.codex|.opencode|.gemini|.agents|dist|build|__pycache__|.venv|venv|.env|coverage|.nyc_output|logs|output|tmp|temp|.claude-plugin|public|static|assets|backup) continue ;;
+                node_modules|.git|.prp|.prp-output|.claude|.codex|.opencode|.gemini|.agents|dist|build|__pycache__|.venv|venv|.env|coverage|.nyc_output|logs|output|tmp|temp|.claude-plugin|public|static|assets|backup|old) continue ;;
                 *.backup|*.backup.*|*.bak|*.old|*.orig|*~|*-backup) continue ;;  # backup/stale dir conventions (#72)
             esac
             if find "$dir" -maxdepth 2 \( -name "*.py" -o -name "*.ts" -o -name "*.js" -o -name "*.go" -o -name "*.rs" -o -name "*.sh" -o -name "*.yaml" \) -print -quit 2>/dev/null | grep -q .; then

--- a/scripts/gen-ai-context.sh
+++ b/scripts/gen-ai-context.sh
@@ -427,15 +427,19 @@ do_check() {
             fi
         done
 
-        # Reverse scan: warn about Context Map entries pointing at backup/stale dirs
+        # Reverse scan: Context Map entries pointing at backup/stale dirs
+        # Uses process substitution (not pipe) so stale=1 propagates to parent shell
         while IFS= read -r entry; do
-            case "$entry" in
-                *.backup|*.backup.*|*.bak|*.old|*.orig|*~|*-backup|backup)
+            local base
+            base=$(basename "$entry")
+            case "$base" in
+                *.backup|*.backup.*|*.bak|*.old|*.orig|*~|*-backup|backup|old)
                     log_warn "Context Map entry '$entry/' matches backup-dir skip pattern — run --update to remove"
                     stale=1
                     ;;
             esac
-        done < <(grep -oE '`[^`]+/`' "$PROJECT_MD" 2>/dev/null | tr -d '`' | sed 's|/$||')
+        done < <(sed -n '/AUTO-GEN:BEGIN/,/AUTO-GEN:END/p' "$PROJECT_MD" \
+                 | grep -oE '`[^`]+/`' | tr -d '`' | sed 's|/$||')
     fi
 
     # Summary


### PR DESCRIPTION
## Summary
- `do_check()` only scanned one direction: "is there a real dir missing from the Context Map?"
- Added reverse scan: "does the Context Map contain entries pointing at dirs we now skip (backup patterns)?"
- Uses same skip patterns as `generate_context_map()` and the forward scan: `*.backup|*.bak|*.old|*.orig|*~|*-backup|backup`
- Sets `stale=1` and warns operator to run `--update`

## Test plan
- [x] Verified stale entries (`mycode.backup/`, `data.bak/`) detected with warning + stale exit code
- [x] Verified clean Context Map produces no false positives
- [x] Verified edge cases: plain `backup/`, `old-code~/`, `app-backup/` caught; `backup-utils/` correctly ignored
- [x] Verified `--update` already removes these entries (existing behavior from #73)

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)