### PR TITLE
fix(install): skip CLAUDE.md PRP inject for soul-orchestra agent homes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -436,9 +436,17 @@ GITIGNORE2
 fi
 
 # Inject PRP section into CLAUDE.md
+# Exception: soul-orchestra agent homes already surface PRP commands via
+# tools_knowledge: in agent YAML — injecting here causes a flap cycle where
+# deploy.py regen overwrites the inject, then prp-install-all re-adds it.
+# Same marker detection as the AGENTS.md skip above (agent-devops#84).
 if ! $SKIP_INJECT; then
-    echo "→ Injecting PRP section into CLAUDE.md"
-    "$FRAMEWORK_DIR/scripts/inject-claude-md.sh" "$PROJECT_DIR"
+    if $_skip_agents_md; then
+        echo "→ CLAUDE.md PRP inject — skipped: soul-orchestra agent home (PRP info via tools_knowledge)"
+    else
+        echo "→ Injecting PRP section into CLAUDE.md"
+        "$FRAMEWORK_DIR/scripts/inject-claude-md.sh" "$PROJECT_DIR"
+    fi
 else
     echo -e "${YELLOW}→ Skipping CLAUDE.md injection (--no-inject)${NC}"
 fi


### PR DESCRIPTION
## Summary

Skip the PRP Workflow section injection into CLAUDE.md when the target repo is a soul-orchestra-managed agent home. Mirrors the AGENTS.md skip logic from #69.

**Problem**: `prp-install-all` injects PRP section → `soul-orchestra deploy` overwrites → inject re-added → cycle repeats. No data loss but unpredictable CLAUDE.md state + commit noise.

**Fix**: Reuse the existing `$_skip_agents_md` detection (grep for `<!-- Generated by soul-orchestra generate-claude-md.py` marker). Soul-orchestra agents already have PRP commands via `tools_knowledge:` in their YAML.

**Tested**:
- agent-psak: CLAUDE.md md5 identical before/after `prp-install` (skip works)
- sniper-s50: inject still runs normally (non-soul-orchestra repo unaffected)

Fixes gobikom/agent-devops#84

## Test plan

- [x] `prp-install` on soul-orchestra agent home → inject skipped, md5 unchanged
- [x] `prp-install` on non-soul-orchestra repo → inject runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)