### PR TITLE
fix(gen-ai-context): add entry point detection for Python/Go/Rust/Java (#63)

### DIFF
--- a/scripts/gen-ai-context.sh
+++ b/scripts/gen-ai-context.sh
@@ -120,7 +120,7 @@ detect_entry_points() {
         local pyproject_scripts
         pyproject_scripts=$(awk '/^\[project\.scripts\]/{found=1; next} found && /^\[/{exit} found' \
             pyproject.toml 2>/dev/null \
-            | grep '=' | awk -F'=' '{gsub(/[ \t]/, "", $1); print $1}' | head -3)
+            | grep '=' | awk -F'=' '{gsub(/[ \t]/, "", $1); print $1}' | head -3 || true)
         while IFS= read -r scr; do
             [ -n "$scr" ] && entries+=("pyproject.toml → $scr")
         done <<< "$pyproject_scripts"
@@ -140,8 +140,10 @@ detect_entry_points() {
         [ -f "$f" ] && entries+=("$f")
     done
     # Java/Kotlin: Application.java or Main.java in Maven/Gradle layout
-    local java_entry
-    java_entry=$(find src/main/java -maxdepth 6 \( -name "Application.java" -o -name "Main.java" \) -print 2>/dev/null | head -1)
+    local java_entry=""
+    if [ -d "src/main/java" ]; then
+        java_entry=$(find src/main/java -maxdepth 6 \( -name "Application.java" -o -name "Main.java" \) -print 2>/dev/null | head -1 || true)
+    fi
     [ -n "$java_entry" ] && entries+=("${java_entry#./}")
     [ -d "bin" ] && {
         for f in bin/*; do
@@ -150,13 +152,15 @@ detect_entry_points() {
     }
     # Fallback: language detected but no entry found
     if [ "${#entries[@]}" -eq 0 ]; then
-        local has_python=false has_go=false has_rust=false
+        local has_python=false has_go=false has_rust=false has_java=false
         { [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ]; } && has_python=true
         [ -f "go.mod" ] && has_go=true
         [ -f "Cargo.toml" ] && has_rust=true
-        $has_python && entries+=("Python detected — add entry manually")
-        $has_go && entries+=("Go detected — add entry manually")
-        $has_rust && entries+=("Rust detected — add entry manually")
+        { [ -f "pom.xml" ] || [ -f "build.gradle" ]; } && has_java=true
+        [ "$has_python" = true ] && entries+=("Python detected — add entry manually")
+        [ "$has_go" = true ]     && entries+=("Go detected — add entry manually")
+        [ "$has_rust" = true ]   && entries+=("Rust detected — add entry manually")
+        [ "$has_java" = true ]   && entries+=("Java/Kotlin detected — add entry manually")
     fi
 
     local result=""

--- a/scripts/gen-ai-context.sh
+++ b/scripts/gen-ai-context.sh
@@ -115,11 +115,49 @@ detect_entry_points() {
     [ -f "src/index.ts" ] && entries+=("src/index.ts")
     [ -f "src/index.js" ] && entries+=("src/index.js")
     [ -f "src/main.py" ] && entries+=("src/main.py")
+    # Python: pyproject.toml [project.scripts] (PEP 621)
+    if [ -f "pyproject.toml" ]; then
+        local pyproject_scripts
+        pyproject_scripts=$(awk '/^\[project\.scripts\]/{found=1; next} found && /^\[/{exit} found' \
+            pyproject.toml 2>/dev/null \
+            | grep '=' | awk -F'=' '{gsub(/[ \t]/, "", $1); print $1}' | head -3)
+        while IFS= read -r scr; do
+            [ -n "$scr" ] && entries+=("pyproject.toml → $scr")
+        done <<< "$pyproject_scripts"
+    fi
+    # Python: */__main__.py (python -m <package>)
+    for f in */__main__.py; do
+        [ -f "$f" ] && entries+=("python -m $(dirname "$f")")
+    done
+    # Go: main.go at root + cmd/*/main.go (standard Go layout)
+    [ -f "main.go" ] && entries+=("main.go")
+    for f in cmd/*/main.go; do
+        [ -f "$f" ] && entries+=("$f")
+    done
+    # Rust: src/main.rs + src/bin/*.rs
+    [ -f "src/main.rs" ] && entries+=("src/main.rs")
+    for f in src/bin/*.rs; do
+        [ -f "$f" ] && entries+=("$f")
+    done
+    # Java/Kotlin: Application.java or Main.java in Maven/Gradle layout
+    local java_entry
+    java_entry=$(find src/main/java -maxdepth 6 \( -name "Application.java" -o -name "Main.java" \) -print 2>/dev/null | head -1)
+    [ -n "$java_entry" ] && entries+=("${java_entry#./}")
     [ -d "bin" ] && {
         for f in bin/*; do
             [ -x "$f" ] && entries+=("$f")
         done
     }
+    # Fallback: language detected but no entry found
+    if [ "${#entries[@]}" -eq 0 ]; then
+        local has_python=false has_go=false has_rust=false
+        { [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ]; } && has_python=true
+        [ -f "go.mod" ] && has_go=true
+        [ -f "Cargo.toml" ] && has_rust=true
+        $has_python && entries+=("Python detected — add entry manually")
+        $has_go && entries+=("Go detected — add entry manually")
+        $has_rust && entries+=("Rust detected — add entry manually")
+    fi
 
     local result=""
     for e in "${entries[@]}"; do

--- a/scripts/gen-ai-context.sh
+++ b/scripts/gen-ai-context.sh
@@ -120,7 +120,8 @@ detect_entry_points() {
         local pyproject_scripts
         pyproject_scripts=$(awk '/^\[project\.scripts\]/{found=1; next} found && /^\[/{exit} found' \
             pyproject.toml 2>/dev/null \
-            | grep '=' | awk -F'=' '{gsub(/[ \t]/, "", $1); print $1}' | head -3 || true)
+            | grep '=' | awk -F'=' '{gsub(/[ \t]/, "", $1); print $1}' | head -3 \
+            || true)
         while IFS= read -r scr; do
             [ -n "$scr" ] && entries+=("pyproject.toml → $scr")
         done <<< "$pyproject_scripts"
@@ -144,7 +145,7 @@ detect_entry_points() {
     if [ -d "src/main/java" ]; then
         java_entry=$(find src/main/java -maxdepth 6 \( -name "Application.java" -o -name "Main.java" \) -print 2>/dev/null | head -1 || true)
     fi
-    [ -n "$java_entry" ] && entries+=("${java_entry#./}")
+    [ -n "$java_entry" ] && entries+=("$java_entry")
     [ -d "bin" ] && {
         for f in bin/*; do
             [ -x "$f" ] && entries+=("$f")


### PR DESCRIPTION
## Summary

Extends `detect_entry_points()` in `scripts/gen-ai-context.sh` to detect entry points for Python, Go, Rust, and Java repos. Previously these all returned `(none detected)`, causing 4 of 5 Python repos in the gobikom ecosystem to show empty entry fields in PROJECT.md.

Implements **Option B (Hybrid)** from issue #63.

## Changes

- Python: parse `[project.scripts]` from `pyproject.toml` (PEP 621) via flag-based awk pattern
- Python: detect `*/__main__.py` (1 level deep, enables `python -m <package>` display)
- Go: detect `main.go` at root + `cmd/*/main.go` (standard Go layout)
- Rust: detect `src/main.rs` + `src/bin/*.rs`
- Java/Kotlin: detect `Application.java`/`Main.java` in Maven layout (`src/main/java/**`)
- Fallback: "Language detected — add entry manually" when stack detected but no entry found

## Files Changed

1 file changed

<details>
<summary>File list</summary>

- `scripts/gen-ai-context.sh` (+38 lines, `detect_entry_points()` function only)

</details>

## Implementation Notes

**awk range pattern bug fixed**: Initial approach used `/^\[project\.scripts\]/,/^\[/` but this self-terminates because the opening `[project.scripts]` line matches both start and end of the range simultaneously. Fixed to flag-based pattern: `awk '/^\[project\.scripts\]/{found=1; next} found && /^\[/{exit} found'`.

No new external dependencies — pure bash.

## Testing

| Repo | Expected | Result |
|------|----------|--------|
| `my-ai-soul-mcp` | `pyproject.toml → soul` | ✅ |
| `multi-agents` | `python -m core` | ✅ |
| `sniper-s50` | `pyproject.toml → download-s50` | ✅ |
| Python (requirements.txt only) | `Python detected — add entry manually` | ✅ |
| Go (synthetic) | `main.go, cmd/server/main.go, cmd/worker/main.go` | ✅ |
| Rust (synthetic) | `src/main.rs, src/bin/cli.rs, src/bin/server.rs` | ✅ |
| Java (synthetic) | `src/main/java/com/example/app/Application.java` | ✅ |
| Node.js (regression) | `src/index.js, npm start → node src/index.js` | ✅ |
| Syntax check | `bash -n` exits 0 | ✅ |

## Related Issues

Closes #63