### PR TITLE
fix(prompts/qa): use --body-file pattern to prevent shell escaping hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ Every major version release MUST include a `docs/migration/vX.0-to-vY.0.md` file
 
 ## [Unreleased]
 
+## [2.8.0] — 2026-05-18
+
+**Shell Safety Hardening** — Fix HEREDOC hang vulnerability in `prp-qa` by replacing inline `--body` with `--body-file` pattern for all `gh issue comment` / `gh issue create` calls.
+
+### Fixed
+
+- **`prompts/qa.md` section 6.4** — replaced inline multiline `--body "..."` with `cat > /tmp/qa-{type}-${RUN_ID}.md << 'EOF' ... EOF` + `--body-file` pattern for both `gh issue comment` and `gh issue create` calls. Prevents shell hang when QA results contain backticks or triple-backtick code blocks (incident `at-3db127abdf91`).
+- **Shell safety warning block** — added `🛑 SHELL SAFETY` callout above section 6.4 documenting the `--body-file` requirement and root cause.
+- **All 5 adapters regenerated** — claude-code, codex, opencode, gemini, antigravity now propagate the `--body-file` pattern from source.
+
 ## [2.7.0] — 2026-05-04
 
 **QA Verification Release** — New `prp-qa` command for acceptance criteria verification via Playwright screenshots, API contract testing, E2E flows, and accessibility checks. Designed for Vera (QA Engineer) agent but usable by any agent. Run-isolated output with auto-incrementing run numbers.

--- a/adapters/antigravity/prp-qa.md
+++ b/adapters/antigravity/prp-qa.md
@@ -419,10 +419,9 @@ gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
 rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
-If no source issue, suggest creating one:
+If no source issue, suggest creating one — display "QA found {N} failures. Create a tracking issue?" then run:
 
 ```bash
-QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF

--- a/adapters/antigravity/prp-qa.md
+++ b/adapters/antigravity/prp-qa.md
@@ -118,6 +118,7 @@ LABEL="{label}"
 LAST_RUN=$(ls -d .prp-output/qa/run-*-* 2>/dev/null | sort -t- -k2 -n | tail -1 | grep -oP 'run-\K\d+' || echo "0")
 NEXT_RUN=$(printf "%03d" $((LAST_RUN + 1)))
 RUN_DIR=".prp-output/qa/run-${NEXT_RUN}-${LABEL}"
+RUN_ID="${NEXT_RUN}-${LABEL}"
 mkdir -p "${RUN_DIR}/screenshots"
 echo "QA Run: ${RUN_DIR}"
 ```
@@ -398,7 +399,7 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
-> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+> **🛑 SHELL SAFETY:** Inline `--body` with multiline content generated at runtime (e.g. QA verdicts, bug reports) **MUST** use `--body-file`. The `<< 'EOF'` (single-quoted delimiter) form is required — never `<< EOF` (unquoted), which performs `$(...)`, backtick, and `${var}` expansion on untrusted content. Pattern fix from incident `at-3db127abdf91`.
 
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
@@ -413,16 +414,21 @@ cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
 
 Tested by: /prp-qa
 EOF
-gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
+  || echo "WARNING: gh failed to post QA comment — body saved at /tmp/qa-comment-${RUN_ID}.md"
+rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
+
 ```bash
-QA found {N} failures. Create a tracking issue?
+QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF
-gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md \
+  || echo "WARNING: gh failed to create QA issue — body saved at /tmp/qa-issue-${RUN_ID}.md"
+rm -f /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/antigravity/prp-qa.md
+++ b/adapters/antigravity/prp-qa.md
@@ -398,24 +398,31 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
+> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
 ```bash
 # Comment on the source issue with QA results
-gh issue comment {ISSUE_NUMBER} --body "## QA Results — FAILED ❌
+cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
+## QA Results — FAILED ❌
 
 {summary table}
 
 {bug details}
 
 Tested by: /prp-qa
-"
+EOF
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
-```
+```bash
 QA found {N} failures. Create a tracking issue?
-gh issue create --title "QA: {summary}" --body "{bug reports}"
+cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
+{bug reports}
+EOF
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -1,5 +1,5 @@
 ---
-description: "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity options."
+description: "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity, --verify, --qa-delegate=<agent>, --done options."
 ---
 ## Agent Mode Detection
 
@@ -718,7 +718,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | Review | ~15-30K | **Low** with pre-generated context (without: ~80-150K) |
 | Review Fix | ~5-10K | If issues found |
 | Re-verify | ~10-15K | **Low** with `--since-last-review` (incremental) |
-| **Total** | ~45-85K | ~40% less than without optimization |
+| Verify | ~3-5K | If `--verify` (skipped otherwise) |
+| QA Delegate | ~2K | If `--qa-delegate` (skipped otherwise) |
+| Done | ~2K | If `--done` (skipped otherwise) |
+| **Total** | ~45-85K | ~40% less than without optimization (+7-9K if --verify/--qa-delegate/--done) |
 
 ### Ralph Mode (with --ralph)
 
@@ -752,6 +755,8 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 /prp-run-all --resume                                 # Resume from last failure
 /prp-run-all Add JWT auth --fix-severity critical,high # Fix only blocking issues
 /prp-run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
+/prp-run-all --issue 87 --merge --verify              # Full workflow + requirements verification before merge
+/prp-run-all --issue 87 --merge --verify --qa-delegate=vera --done  # Full autonomous lifecycle with QA + issue closure
 ```
 
 ---
@@ -777,6 +782,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | `--merge` but review has remaining issues | Skip merge, report in summary. Do NOT merge with open issues. |
 | Smart plan detection says "small" but impl is complex | Plan was skipped, implement may struggle. User can re-run with `--prp-path` and explicit plan. |
 | `--issue N` + `--skip-plan` | `--skip-plan` overrides smart plan detection. If no existing plan files found, falls through to stub plan generation in Step 2. To select from existing plans, ensure at least one `.plan.md` exists in `.prp-output/plans/`. |
+| `--done` without `--issue` | SKIP Step 9 with WARN: "`--done` requires `--issue` to identify which issue to close." |
+| `--qa-delegate` without `--issue` | SKIP Step 8.5 with WARN: "`--qa-delegate` requires `--issue` to source acceptance criteria." |
+| `--verify` returns FAIL | STOP — do not merge. Report which criteria failed. User must fix and re-run with `--verify`. |
+| `--done` but Gate 4 PENDING (QA delegated, not yet posted) | Issue NOT closed. Re-run `/prp-done {ISSUE_NUMBER}` after Vera posts QA results. |
 
 ---
 
@@ -794,6 +803,9 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 - ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
 - NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
+- VERIFIED: Verify artifact exists and PASS/PARTIAL verdict recorded if --verify (FAIL blocks merge)
+- QA_DELEGATED: QA task dispatched to target agent if --qa-delegate (async, does not block merge)
+- ISSUE_CLOSED: Issue closed via /prp-done if --done and all gates pass; PENDING blocks without error
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion
 - SUMMARY_REPORTED: User has clear next steps

--- a/adapters/claude-code/prp-qa.md
+++ b/adapters/claude-code/prp-qa.md
@@ -400,24 +400,31 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
+> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
 ```bash
 # Comment on the source issue with QA results
-gh issue comment {ISSUE_NUMBER} --body "## QA Results — FAILED ❌
+cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
+## QA Results — FAILED ❌
 
 {summary table}
 
 {bug details}
 
 Tested by: /prp-core:prp-qa
-"
+EOF
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
-```
+```bash
 QA found {N} failures. Create a tracking issue?
-gh issue create --title "QA: {summary}" --body "{bug reports}"
+cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
+{bug reports}
+EOF
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/claude-code/prp-qa.md
+++ b/adapters/claude-code/prp-qa.md
@@ -120,6 +120,7 @@ LABEL="{label}"
 LAST_RUN=$(ls -d .prp-output/qa/run-*-* 2>/dev/null | sort -t- -k2 -n | tail -1 | grep -oP 'run-\K\d+' || echo "0")
 NEXT_RUN=$(printf "%03d" $((LAST_RUN + 1)))
 RUN_DIR=".prp-output/qa/run-${NEXT_RUN}-${LABEL}"
+RUN_ID="${NEXT_RUN}-${LABEL}"
 mkdir -p "${RUN_DIR}/screenshots"
 echo "QA Run: ${RUN_DIR}"
 ```
@@ -400,7 +401,7 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
-> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+> **🛑 SHELL SAFETY:** Inline `--body` with multiline content generated at runtime (e.g. QA verdicts, bug reports) **MUST** use `--body-file`. The `<< 'EOF'` (single-quoted delimiter) form is required — never `<< EOF` (unquoted), which performs `$(...)`, backtick, and `${var}` expansion on untrusted content. Pattern fix from incident `at-3db127abdf91`.
 
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
@@ -415,16 +416,21 @@ cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
 
 Tested by: /prp-core:prp-qa
 EOF
-gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
+  || echo "WARNING: gh failed to post QA comment — body saved at /tmp/qa-comment-${RUN_ID}.md"
+rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
+
 ```bash
-QA found {N} failures. Create a tracking issue?
+QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF
-gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md \
+  || echo "WARNING: gh failed to create QA issue — body saved at /tmp/qa-issue-${RUN_ID}.md"
+rm -f /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/claude-code/prp-qa.md
+++ b/adapters/claude-code/prp-qa.md
@@ -421,10 +421,9 @@ gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
 rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
-If no source issue, suggest creating one:
+If no source issue, suggest creating one — display "QA found {N} failures. Create a tracking issue?" then run:
 
 ```bash
-QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -1,6 +1,6 @@
 ---
 description: "Orchestrate complete PRP workflow from feature request to pull request. Run branch, plan, implement, commit, PR, review with fix loop, and summary in sequence. Use when implementing features using PRP methodology or when user requests full PRP workflow."
-argument-hint: "\"<feature-description>\" or --issue <N> [--merge] [--max-review-rounds N] [--prp-path <path>] [--skip-plan] [--fast] [--ralph] [--ralph-max-iter N] [--skip-review] [--no-pr] [--fix-severity <levels>] [--resume] [--no-interact] [--dry-run]"
+argument-hint: "\"<feature-description>\" or --issue <N> [--merge] [--max-review-rounds N] [--prp-path <path>] [--skip-plan] [--fast] [--ralph] [--ralph-max-iter N] [--skip-review] [--no-pr] [--fix-severity <levels>] [--resume] [--no-interact] [--dry-run] [--verify] [--qa-delegate=<agent>] [--done]"
 ---
 <process>
 ## Agent Mode Detection
@@ -720,7 +720,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | Review | ~15-30K | **Low** with pre-generated context (without: ~80-150K) |
 | Review Fix | ~5-10K | If issues found |
 | Re-verify | ~10-15K | **Low** with `--since-last-review` (incremental) |
-| **Total** | ~45-85K | ~40% less than without optimization |
+| Verify | ~3-5K | If `--verify` (skipped otherwise) |
+| QA Delegate | ~2K | If `--qa-delegate` (skipped otherwise) |
+| Done | ~2K | If `--done` (skipped otherwise) |
+| **Total** | ~45-85K | ~40% less than without optimization (+7-9K if --verify/--qa-delegate/--done) |
 
 ### Ralph Mode (with --ralph)
 
@@ -754,6 +757,8 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 /prp-core:prp-run-all --resume                                 # Resume from last failure
 /prp-core:prp-run-all Add JWT auth --fix-severity critical,high # Fix only blocking issues
 /prp-core:prp-run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
+/prp-core:prp-run-all --issue 87 --merge --verify              # Full workflow + requirements verification before merge
+/prp-core:prp-run-all --issue 87 --merge --verify --qa-delegate=vera --done  # Full autonomous lifecycle with QA + issue closure
 ```
 
 ---
@@ -779,6 +784,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | `--merge` but review has remaining issues | Skip merge, report in summary. Do NOT merge with open issues. |
 | Smart plan detection says "small" but impl is complex | Plan was skipped, implement may struggle. User can re-run with `--prp-path` and explicit plan. |
 | `--issue N` + `--skip-plan` | `--skip-plan` overrides smart plan detection. If no existing plan files found, falls through to stub plan generation in Step 2. To select from existing plans, ensure at least one `.plan.md` exists in `.prp-output/plans/`. |
+| `--done` without `--issue` | SKIP Step 9 with WARN: "`--done` requires `--issue` to identify which issue to close." |
+| `--qa-delegate` without `--issue` | SKIP Step 8.5 with WARN: "`--qa-delegate` requires `--issue` to source acceptance criteria." |
+| `--verify` returns FAIL | STOP — do not merge. Report which criteria failed. User must fix and re-run with `--verify`. |
+| `--done` but Gate 4 PENDING (QA delegated, not yet posted) | Issue NOT closed. Re-run `/prp-core:prp-done {ISSUE_NUMBER}` after Vera posts QA results. |
 
 ---
 
@@ -796,6 +805,9 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 - ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
 - NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
+- VERIFIED: Verify artifact exists and PASS/PARTIAL verdict recorded if --verify (FAIL blocks merge)
+- QA_DELEGATED: QA task dispatched to target agent if --qa-delegate (async, does not block merge)
+- ISSUE_CLOSED: Issue closed via /prp-core:prp-done if --done and all gates pass; PENDING blocks without error
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion
 - SUMMARY_REPORTED: User has clear next steps

--- a/adapters/codex/prp-qa/SKILL.md
+++ b/adapters/codex/prp-qa/SKILL.md
@@ -121,6 +121,7 @@ LABEL="{label}"
 LAST_RUN=$(ls -d .prp-output/qa/run-*-* 2>/dev/null | sort -t- -k2 -n | tail -1 | grep -oP 'run-\K\d+' || echo "0")
 NEXT_RUN=$(printf "%03d" $((LAST_RUN + 1)))
 RUN_DIR=".prp-output/qa/run-${NEXT_RUN}-${LABEL}"
+RUN_ID="${NEXT_RUN}-${LABEL}"
 mkdir -p "${RUN_DIR}/screenshots"
 echo "QA Run: ${RUN_DIR}"
 ```
@@ -401,7 +402,7 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
-> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+> **🛑 SHELL SAFETY:** Inline `--body` with multiline content generated at runtime (e.g. QA verdicts, bug reports) **MUST** use `--body-file`. The `<< 'EOF'` (single-quoted delimiter) form is required — never `<< EOF` (unquoted), which performs `$(...)`, backtick, and `${var}` expansion on untrusted content. Pattern fix from incident `at-3db127abdf91`.
 
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
@@ -416,16 +417,21 @@ cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
 
 Tested by: $prp-qa
 EOF
-gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
+  || echo "WARNING: gh failed to post QA comment — body saved at /tmp/qa-comment-${RUN_ID}.md"
+rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
+
 ```bash
-QA found {N} failures. Create a tracking issue?
+QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF
-gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md \
+  || echo "WARNING: gh failed to create QA issue — body saved at /tmp/qa-issue-${RUN_ID}.md"
+rm -f /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/codex/prp-qa/SKILL.md
+++ b/adapters/codex/prp-qa/SKILL.md
@@ -401,24 +401,31 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
+> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
 ```bash
 # Comment on the source issue with QA results
-gh issue comment {ISSUE_NUMBER} --body "## QA Results — FAILED ❌
+cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
+## QA Results — FAILED ❌
 
 {summary table}
 
 {bug details}
 
 Tested by: $prp-qa
-"
+EOF
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
-```
+```bash
 QA found {N} failures. Create a tracking issue?
-gh issue create --title "QA: {summary}" --body "{bug reports}"
+cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
+{bug reports}
+EOF
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/codex/prp-qa/SKILL.md
+++ b/adapters/codex/prp-qa/SKILL.md
@@ -422,10 +422,9 @@ gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
 rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
-If no source issue, suggest creating one:
+If no source issue, suggest creating one — display "QA found {N} failures. Create a tracking issue?" then run:
 
 ```bash
-QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prp-run-all
-description: "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity options."
+description: "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity, --verify, --qa-delegate=<agent>, --done options."
 metadata:
   short-description: Full PRP workflow
 ---
@@ -721,7 +721,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | Review | ~15-30K | **Low** with pre-generated context (without: ~80-150K) |
 | Review Fix | ~5-10K | If issues found |
 | Re-verify | ~10-15K | **Low** with `--since-last-review` (incremental) |
-| **Total** | ~45-85K | ~40% less than without optimization |
+| Verify | ~3-5K | If `--verify` (skipped otherwise) |
+| QA Delegate | ~2K | If `--qa-delegate` (skipped otherwise) |
+| Done | ~2K | If `--done` (skipped otherwise) |
+| **Total** | ~45-85K | ~40% less than without optimization (+7-9K if --verify/--qa-delegate/--done) |
 
 ### Ralph Mode (with --ralph)
 
@@ -755,6 +758,8 @@ $prp-run-all Add JWT auth --dry-run                   # Preview without executin
 $prp-run-all --resume                                 # Resume from last failure
 $prp-run-all Add JWT auth --fix-severity critical,high # Fix only blocking issues
 $prp-run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
+$prp-run-all --issue 87 --merge --verify              # Full workflow + requirements verification before merge
+$prp-run-all --issue 87 --merge --verify --qa-delegate=vera --done  # Full autonomous lifecycle with QA + issue closure
 ```
 
 ---
@@ -780,6 +785,10 @@ $prp-run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
 | `--merge` but review has remaining issues | Skip merge, report in summary. Do NOT merge with open issues. |
 | Smart plan detection says "small" but impl is complex | Plan was skipped, implement may struggle. User can re-run with `--prp-path` and explicit plan. |
 | `--issue N` + `--skip-plan` | `--skip-plan` overrides smart plan detection. If no existing plan files found, falls through to stub plan generation in Step 2. To select from existing plans, ensure at least one `.plan.md` exists in `.prp-output/plans/`. |
+| `--done` without `--issue` | SKIP Step 9 with WARN: "`--done` requires `--issue` to identify which issue to close." |
+| `--qa-delegate` without `--issue` | SKIP Step 8.5 with WARN: "`--qa-delegate` requires `--issue` to source acceptance criteria." |
+| `--verify` returns FAIL | STOP — do not merge. Report which criteria failed. User must fix and re-run with `--verify`. |
+| `--done` but Gate 4 PENDING (QA delegated, not yet posted) | Issue NOT closed. Re-run `$prp-done {ISSUE_NUMBER}` after Vera posts QA results. |
 
 ---
 
@@ -797,6 +806,9 @@ $prp-run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
 - ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
 - NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
+- VERIFIED: Verify artifact exists and PASS/PARTIAL verdict recorded if --verify (FAIL blocks merge)
+- QA_DELEGATED: QA task dispatched to target agent if --qa-delegate (async, does not block merge)
+- ISSUE_CLOSED: Issue closed via $prp-done if --done and all gates pass; PENDING blocks without error
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion
 - SUMMARY_REPORTED: User has clear next steps

--- a/adapters/gemini/qa.toml
+++ b/adapters/gemini/qa.toml
@@ -397,24 +397,31 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
+> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
 ```bash
 # Comment on the source issue with QA results
-gh issue comment {ISSUE_NUMBER} --body "## QA Results — FAILED ❌
+cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
+## QA Results — FAILED ❌
 
 {summary table}
 
 {bug details}
 
 Tested by: /qa
-"
+EOF
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
-```
+```bash
 QA found {N} failures. Create a tracking issue?
-gh issue create --title "QA: {summary}" --body "{bug reports}"
+cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
+{bug reports}
+EOF
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/gemini/qa.toml
+++ b/adapters/gemini/qa.toml
@@ -418,10 +418,9 @@ gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \\
 rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
-If no source issue, suggest creating one:
+If no source issue, suggest creating one — display "QA found {N} failures. Create a tracking issue?" then run:
 
 ```bash
-QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF

--- a/adapters/gemini/qa.toml
+++ b/adapters/gemini/qa.toml
@@ -117,6 +117,7 @@ LABEL="{label}"
 LAST_RUN=$(ls -d .prp-output/qa/run-*-* 2>/dev/null | sort -t- -k2 -n | tail -1 | grep -oP 'run-\\K\\d+' || echo "0")
 NEXT_RUN=$(printf "%03d" $((LAST_RUN + 1)))
 RUN_DIR=".prp-output/qa/run-${NEXT_RUN}-${LABEL}"
+RUN_ID="${NEXT_RUN}-${LABEL}"
 mkdir -p "${RUN_DIR}/screenshots"
 echo "QA Run: ${RUN_DIR}"
 ```
@@ -397,7 +398,7 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
-> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+> **🛑 SHELL SAFETY:** Inline `--body` with multiline content generated at runtime (e.g. QA verdicts, bug reports) **MUST** use `--body-file`. The `<< 'EOF'` (single-quoted delimiter) form is required — never `<< EOF` (unquoted), which performs `$(...)`, backtick, and `${var}` expansion on untrusted content. Pattern fix from incident `at-3db127abdf91`.
 
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
@@ -412,16 +413,21 @@ cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
 
 Tested by: /qa
 EOF
-gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \\
+  || echo "WARNING: gh failed to post QA comment — body saved at /tmp/qa-comment-${RUN_ID}.md"
+rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
+
 ```bash
-QA found {N} failures. Create a tracking issue?
+QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF
-gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md \\
+  || echo "WARNING: gh failed to create QA issue — body saved at /tmp/qa-issue-${RUN_ID}.md"
+rm -f /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -1,4 +1,4 @@
-description = "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity options."
+description = "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity, --verify, --qa-delegate=<agent>, --done options."
 prompt = """
 ## Agent Mode Detection
 
@@ -717,7 +717,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | Review | ~15-30K | **Low** with pre-generated context (without: ~80-150K) |
 | Review Fix | ~5-10K | If issues found |
 | Re-verify | ~10-15K | **Low** with `--since-last-review` (incremental) |
-| **Total** | ~45-85K | ~40% less than without optimization |
+| Verify | ~3-5K | If `--verify` (skipped otherwise) |
+| QA Delegate | ~2K | If `--qa-delegate` (skipped otherwise) |
+| Done | ~2K | If `--done` (skipped otherwise) |
+| **Total** | ~45-85K | ~40% less than without optimization (+7-9K if --verify/--qa-delegate/--done) |
 
 ### Ralph Mode (with --ralph)
 
@@ -751,6 +754,8 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 /run-all --resume                                 # Resume from last failure
 /run-all Add JWT auth --fix-severity critical,high # Fix only blocking issues
 /run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
+/run-all --issue 87 --merge --verify              # Full workflow + requirements verification before merge
+/run-all --issue 87 --merge --verify --qa-delegate=vera --done  # Full autonomous lifecycle with QA + issue closure
 ```
 
 ---
@@ -776,6 +781,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | `--merge` but review has remaining issues | Skip merge, report in summary. Do NOT merge with open issues. |
 | Smart plan detection says "small" but impl is complex | Plan was skipped, implement may struggle. User can re-run with `--prp-path` and explicit plan. |
 | `--issue N` + `--skip-plan` | `--skip-plan` overrides smart plan detection. If no existing plan files found, falls through to stub plan generation in Step 2. To select from existing plans, ensure at least one `.plan.md` exists in `.prp-output/plans/`. |
+| `--done` without `--issue` | SKIP Step 9 with WARN: "`--done` requires `--issue` to identify which issue to close." |
+| `--qa-delegate` without `--issue` | SKIP Step 8.5 with WARN: "`--qa-delegate` requires `--issue` to source acceptance criteria." |
+| `--verify` returns FAIL | STOP — do not merge. Report which criteria failed. User must fix and re-run with `--verify`. |
+| `--done` but Gate 4 PENDING (QA delegated, not yet posted) | Issue NOT closed. Re-run `/done {ISSUE_NUMBER}` after Vera posts QA results. |
 
 ---
 
@@ -793,6 +802,9 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 - ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
 - NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
+- VERIFIED: Verify artifact exists and PASS/PARTIAL verdict recorded if --verify (FAIL blocks merge)
+- QA_DELEGATED: QA task dispatched to target agent if --qa-delegate (async, does not block merge)
+- ISSUE_CLOSED: Issue closed via /done if --done and all gates pass; PENDING blocks without error
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion
 - SUMMARY_REPORTED: User has clear next steps

--- a/adapters/opencode/qa.md
+++ b/adapters/opencode/qa.md
@@ -420,10 +420,9 @@ gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
 rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
-If no source issue, suggest creating one:
+If no source issue, suggest creating one — display "QA found {N} failures. Create a tracking issue?" then run:
 
 ```bash
-QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF

--- a/adapters/opencode/qa.md
+++ b/adapters/opencode/qa.md
@@ -399,24 +399,31 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
+> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
 ```bash
 # Comment on the source issue with QA results
-gh issue comment {ISSUE_NUMBER} --body "## QA Results — FAILED ❌
+cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
+## QA Results — FAILED ❌
 
 {summary table}
 
 {bug details}
 
 Tested by: /prp:qa
-"
+EOF
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
-```
+```bash
 QA found {N} failures. Create a tracking issue?
-gh issue create --title "QA: {summary}" --body "{bug reports}"
+cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
+{bug reports}
+EOF
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/opencode/qa.md
+++ b/adapters/opencode/qa.md
@@ -119,6 +119,7 @@ LABEL="{label}"
 LAST_RUN=$(ls -d .prp-output/qa/run-*-* 2>/dev/null | sort -t- -k2 -n | tail -1 | grep -oP 'run-\K\d+' || echo "0")
 NEXT_RUN=$(printf "%03d" $((LAST_RUN + 1)))
 RUN_DIR=".prp-output/qa/run-${NEXT_RUN}-${LABEL}"
+RUN_ID="${NEXT_RUN}-${LABEL}"
 mkdir -p "${RUN_DIR}/screenshots"
 echo "QA Run: ${RUN_DIR}"
 ```
@@ -399,7 +400,7 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
-> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+> **🛑 SHELL SAFETY:** Inline `--body` with multiline content generated at runtime (e.g. QA verdicts, bug reports) **MUST** use `--body-file`. The `<< 'EOF'` (single-quoted delimiter) form is required — never `<< EOF` (unquoted), which performs `$(...)`, backtick, and `${var}` expansion on untrusted content. Pattern fix from incident `at-3db127abdf91`.
 
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
@@ -414,16 +415,21 @@ cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
 
 Tested by: /prp:qa
 EOF
-gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
+  || echo "WARNING: gh failed to post QA comment — body saved at /tmp/qa-comment-${RUN_ID}.md"
+rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
+
 ```bash
-QA found {N} failures. Create a tracking issue?
+QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF
-gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md \
+  || echo "WARNING: gh failed to create QA issue — body saved at /tmp/qa-issue-${RUN_ID}.md"
+rm -f /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -1,5 +1,5 @@
 ---
-description: "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity options."
+description: "Execute the complete PRP lifecycle end-to-end — issue context, smart plan, implement, commit, PR, review-fix loop (until 0 issues), merge, and cleanup. Supports --issue, --merge, --max-review-rounds, --fast, --ralph, --skip-plan, --skip-review, --no-pr, --resume, --no-interact, --dry-run, --fix-severity, --verify, --qa-delegate=<agent>, --done options."
 agent: plan
 ---
 ## Agent Mode Detection
@@ -719,7 +719,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | Review | ~15-30K | **Low** with pre-generated context (without: ~80-150K) |
 | Review Fix | ~5-10K | If issues found |
 | Re-verify | ~10-15K | **Low** with `--since-last-review` (incremental) |
-| **Total** | ~45-85K | ~40% less than without optimization |
+| Verify | ~3-5K | If `--verify` (skipped otherwise) |
+| QA Delegate | ~2K | If `--qa-delegate` (skipped otherwise) |
+| Done | ~2K | If `--done` (skipped otherwise) |
+| **Total** | ~45-85K | ~40% less than without optimization (+7-9K if --verify/--qa-delegate/--done) |
 
 ### Ralph Mode (with --ralph)
 
@@ -753,6 +756,8 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 /prp:run-all --resume                                 # Resume from last failure
 /prp:run-all Add JWT auth --fix-severity critical,high # Fix only blocking issues
 /prp:run-all --issue 55 --max-review-rounds 3 --merge # Custom review rounds
+/prp:run-all --issue 87 --merge --verify              # Full workflow + requirements verification before merge
+/prp:run-all --issue 87 --merge --verify --qa-delegate=vera --done  # Full autonomous lifecycle with QA + issue closure
 ```
 
 ---
@@ -778,6 +783,10 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 | `--merge` but review has remaining issues | Skip merge, report in summary. Do NOT merge with open issues. |
 | Smart plan detection says "small" but impl is complex | Plan was skipped, implement may struggle. User can re-run with `--prp-path` and explicit plan. |
 | `--issue N` + `--skip-plan` | `--skip-plan` overrides smart plan detection. If no existing plan files found, falls through to stub plan generation in Step 2. To select from existing plans, ensure at least one `.plan.md` exists in `.prp-output/plans/`. |
+| `--done` without `--issue` | SKIP Step 9 with WARN: "`--done` requires `--issue` to identify which issue to close." |
+| `--qa-delegate` without `--issue` | SKIP Step 8.5 with WARN: "`--qa-delegate` requires `--issue` to source acceptance criteria." |
+| `--verify` returns FAIL | STOP — do not merge. Report which criteria failed. User must fix and re-run with `--verify`. |
+| `--done` but Gate 4 PENDING (QA delegated, not yet posted) | Issue NOT closed. Re-run `/prp:done {ISSUE_NUMBER}` after Vera posts QA results. |
 
 ---
 
@@ -795,6 +804,9 @@ This will: check all completion gates (PR merged, review artifact, verify artifa
 - ZERO_ISSUES_TARGET: Review-fix loop continues until 0 issues (all severities in `FIX_SEVERITY`) or MAX_CYCLES reached. **Skipped issues count as remaining** — they are deferred, not resolved. Re-verify uses FULL review (not incremental) when any issues were skipped in the prior round, so skipped items re-surface in the next evaluation.
 - NO_SILENT_MERGE: `--merge` only executes when `REVIEW_VERDICT = "0_issues"`. `needs_manual_fix` (MAX_CYCLES hit OR 2 rounds all-skipped) blocks merge; escalation GH issue is created instead.
 - MERGED: PR squash-merged if --merge and 0 issues (unless --no-pr or --skip-review)
+- VERIFIED: Verify artifact exists and PASS/PARTIAL verdict recorded if --verify (FAIL blocks merge)
+- QA_DELEGATED: QA task dispatched to target agent if --qa-delegate (async, does not block merge)
+- ISSUE_CLOSED: Issue closed via /prp:done if --done and all gates pass; PENDING blocks without error
 - CLEANED_UP: Branch deleted, main updated, issue closed if --issue
 - STATE_CLEANED: State and lock files deleted after completion
 - SUMMARY_REPORTED: User has clear next steps

--- a/prompts/qa.md
+++ b/prompts/qa.md
@@ -395,24 +395,31 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
+> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
 ```bash
 # Comment on the source issue with QA results
-gh issue comment {ISSUE_NUMBER} --body "## QA Results — FAILED ❌
+cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
+## QA Results — FAILED ❌
 
 {summary table}
 
 {bug details}
 
 Tested by: {TOOL}:qa
-"
+EOF
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
-```
+```bash
 QA found {N} failures. Create a tracking issue?
-gh issue create --title "QA: {summary}" --body "{bug reports}"
+cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
+{bug reports}
+EOF
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/prompts/qa.md
+++ b/prompts/qa.md
@@ -115,6 +115,7 @@ LABEL="{label}"
 LAST_RUN=$(ls -d .prp-output/qa/run-*-* 2>/dev/null | sort -t- -k2 -n | tail -1 | grep -oP 'run-\K\d+' || echo "0")
 NEXT_RUN=$(printf "%03d" $((LAST_RUN + 1)))
 RUN_DIR=".prp-output/qa/run-${NEXT_RUN}-${LABEL}"
+RUN_ID="${NEXT_RUN}-${LABEL}"
 mkdir -p "${RUN_DIR}/screenshots"
 echo "QA Run: ${RUN_DIR}"
 ```
@@ -395,7 +396,7 @@ For each failed criterion, generate a structured bug report:
 
 ### 6.4 Issue Creation (On Failure)
 
-> **🛑 SHELL SAFETY:** Multiline `--body` with backticks/code blocks **MUST** use `--body-file`. Inline `--body "$(cat <<EOF)"` executes backticks as bash subshells → hangs on stdin → 600s timeout. Pattern fix from incident `at-3db127abdf91`.
+> **🛑 SHELL SAFETY:** Inline `--body` with multiline content generated at runtime (e.g. QA verdicts, bug reports) **MUST** use `--body-file`. The `<< 'EOF'` (single-quoted delimiter) form is required — never `<< EOF` (unquoted), which performs `$(...)`, backtick, and `${var}` expansion on untrusted content. Pattern fix from incident `at-3db127abdf91`.
 
 If verdict is QA FAILED and there is a source issue (`--issue`):
 
@@ -410,16 +411,21 @@ cat > /tmp/qa-comment-${RUN_ID}.md << 'EOF'
 
 Tested by: {TOOL}:qa
 EOF
-gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md
+gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
+  || echo "WARNING: gh failed to post QA comment — body saved at /tmp/qa-comment-${RUN_ID}.md"
+rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
 If no source issue, suggest creating one:
+
 ```bash
-QA found {N} failures. Create a tracking issue?
+QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF
-gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md
+gh issue create --title "QA: {summary}" --body-file /tmp/qa-issue-${RUN_ID}.md \
+  || echo "WARNING: gh failed to create QA issue — body saved at /tmp/qa-issue-${RUN_ID}.md"
+rm -f /tmp/qa-issue-${RUN_ID}.md
 ```
 
 ---

--- a/prompts/qa.md
+++ b/prompts/qa.md
@@ -416,10 +416,9 @@ gh issue comment {ISSUE_NUMBER} --body-file /tmp/qa-comment-${RUN_ID}.md \
 rm -f /tmp/qa-comment-${RUN_ID}.md
 ```
 
-If no source issue, suggest creating one:
+If no source issue, suggest creating one — display "QA found {N} failures. Create a tracking issue?" then run:
 
 ```bash
-QA found {N} failures. Suggest creating a tracking issue:
 cat > /tmp/qa-issue-${RUN_ID}.md << 'EOF'
 {bug reports}
 EOF


### PR DESCRIPTION
## Summary

- Replaces inline `--body "..."` with `cat > /tmp/qa-*-${RUN_ID}.md << 'EOF' + --body-file` in `prompts/qa.md` section 6.4 — fixes HEREDOC hang when QA results contain backticks/code blocks (incident `at-3db127abdf91`)
- Adds `🛑 SHELL SAFETY` warning callout above section 6.4
- Bumps version to 2.8.0 in CHANGELOG.md
- Regenerates all 5 adapters via `scripts/generate-adapters.py` (includes pre-existing run-all adapter drift fix)

**Parent epic**: gobikom/agent-devops#185 (Layer L2)

## AC Verification

| AC | Status |
|----|--------|
| AC1: `gh issue comment` → `--body-file` | ✅ |
| AC2: `gh issue create` → `--body-file` | ✅ |
| AC3: SHELL SAFETY warning block added | ✅ |
| AC4: `python3 scripts/generate-adapters.py` run | ✅ 5 generated, 0 errors |
| AC5: ≥2 `body-file` per adapter (actual: 3) | ✅ |
| AC6: No hand-edits to adapter files | ✅ |
| AC7: Version bump 2.7.0 → 2.8.0 | ✅ |

## Test plan

- [ ] Verify `grep -c body-file adapters/{claude-code,antigravity}/prp-qa.md` returns ≥2
- [ ] Verify `python3 scripts/generate-adapters.py` is idempotent (run twice, no changes)
- [ ] Verify no new bats parity test failures

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)