### PR TITLE
feat: auto-worktree isolation for concurrent multi-agent work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,32 @@ Every major version release MUST include a `docs/migration/vX.0-to-vY.0.md` file
 
 ## [Unreleased]
 
+## [2.9.0] — 2026-05-21
+
+**Auto-worktree isolation** — `prp-implement` and `prp-run-all` now create a `git worktree` when starting on main instead of `git checkout -b`. Each agent gets an isolated working copy under `/tmp/prp-worktree/`. Eliminates mixed commits, stash conflicts, and branch clobbering when multiple agents work on the same repo simultaneously.
+
+### Added
+
+- **Auto-worktree creation** in `implement.md` Phase 2 and `run-all.md` Step 1 — when on main, creates `/tmp/prp-worktree/{user}-{branch}` with isolated copy
+- **`.prp-output/` symlink** — artifacts symlinked back to original repo root, survive worktree removal
+- **`WORKTREE_PATH` state variable** in `run-all.md` — persisted in state file, restored on `--resume` with prefix validation (`/tmp/prp-worktree/*`)
+- **Worktree cleanup** in `cleanup.md` Phase 4.2 — removes worktree before branch deletion, uses `git -C` for reliable cwd handling
+- **Error guards** — `REPO_ROOT` empty check, `cd || STOP`, `ln || STOP`, `mkdir -p /tmp/prp-worktree`, fallback to `git checkout -b` if worktree creation fails
+- **Dirty working tree warning** — WARN (not STOP) when uncommitted changes exist on main before worktree creation
+
+### Changed
+
+- `implement.md` Phase 2 Branch Decision table — reordered, worktree-first instead of checkout-first
+- `run-all.md` Step 1 — renamed "CREATE BRANCH" → "CREATE BRANCH + WORKTREE"
+- `cleanup.md` Phase 4 — renumbered sections (4.2 Worktree → 4.3 Local Branch → 4.4 Remote → 4.5 Prune → 4.6 State)
+- All 15 adapters regenerated (5 tools × 3 commands)
+
+### Notes
+
+- Backward compatible: old state files without `worktree_path` field work normally (treated as empty → skip worktree cd)
+- Falls back to `git checkout -b` when worktree creation fails — no hard dependency on worktree support
+- Covers 5 of 8 agent code modification paths (task_executor, delegate-dev, dev-task v1/v3, orchestrate). Direct ping/ask paths remain convention-based (CLAUDE.md rule).
+
 ## [2.8.1] — 2026-05-18
 
 **Documentation amendment** — Retroactively documents `prp-verify`, `prp-done`, `prp-qa --delegate`, `safe-merge` Gate 2, and new `prp-run-all` flags (`--verify`, `--qa-delegate`, `--done`) shipped in PR #82 (commit `fe6b441`, 2026-05-16) but omitted from the v2.8.0 CHANGELOG (which focused on the shell safety fix). No code changes — docs only.

--- a/adapters/antigravity/prp-cleanup.md
+++ b/adapters/antigravity/prp-cleanup.md
@@ -208,7 +208,7 @@ git branch -D {branch}
 
 **If still fails** (branch doesn't exist locally): Skip — already deleted.
 
-### 4.3 Delete Remote Branch
+### 4.4 Delete Remote Branch
 
 ```bash
 git push origin --delete {branch}

--- a/adapters/antigravity/prp-cleanup.md
+++ b/adapters/antigravity/prp-cleanup.md
@@ -183,7 +183,18 @@ Action: Delete local + remote
 
 **If `DRY_RUN`**: Show preview only, skip deletion.
 
-### 4.2 Delete Local Branch
+### 4.2 Remove Worktree (if exists)
+
+```bash
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+if [ -d "$WORKTREE_PATH" ]; then
+    cd ~  # exit worktree before removing
+    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git worktree remove --force "$WORKTREE_PATH"
+fi
+```
+
+### 4.3 Delete Local Branch
 
 ```bash
 git branch -d {branch}

--- a/adapters/antigravity/prp-cleanup.md
+++ b/adapters/antigravity/prp-cleanup.md
@@ -187,10 +187,11 @@ Action: Delete local + remote
 
 ```bash
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
-if [ -d "$WORKTREE_PATH" ]; then
-    cd ~  # exit worktree before removing
-    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
-      git worktree remove --force "$WORKTREE_PATH"
+if [ -d "$WORKTREE_PATH" ] && [[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")"
+    git -C "$REPO_ROOT" worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_PATH" || \
+      echo "WARN: Could not remove worktree at $WORKTREE_PATH — run 'git worktree prune' manually."
 fi
 ```
 
@@ -217,13 +218,13 @@ git push origin --delete {branch}
 **If fails** (already deleted): Skip — already cleaned up.
 **If fails** (permission denied): WARN — "Cannot delete remote branch. Check permissions."
 
-### 4.4 Prune Remote References
+### 4.5 Prune Remote References
 
 ```bash
 git remote prune origin
 ```
 
-### 4.5 Remove Orphaned State Files
+### 4.6 Remove Orphaned State Files
 
 ```bash
 # Remove run-all state file if it refers to the cleaned branch

--- a/adapters/antigravity/prp-implement.md
+++ b/adapters/antigravity/prp-implement.md
@@ -135,25 +135,28 @@ git worktree list
 |---------------|--------|
 | Already in a worktree | Use it (log: "Using existing worktree") |
 | On feature branch (not main) | Use it (log: "Using existing branch") |
-| On main | Create isolated worktree (see below) |
+| On main, dirty | WARN: "Uncommitted changes on main will NOT be included in the worktree." Then proceed. |
+| On main, clean | Create isolated worktree (see below) |
 
 **Worktree creation (when on main):**
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    # Symlink .prp-output back to original repo so artifacts survive worktree removal
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed — artifacts would be lost on cleanup"; exit 1; }
 fi
 ```
 

--- a/adapters/antigravity/prp-implement.md
+++ b/adapters/antigravity/prp-implement.md
@@ -140,16 +140,27 @@ git worktree list
 **Worktree creation (when on main):**
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    # Symlink .prp-output back to original repo so artifacts survive worktree removal
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
 The original working tree stays clean — other agents can work there simultaneously.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 ### 2.3 Sync with Remote
 

--- a/adapters/antigravity/prp-implement.md
+++ b/adapters/antigravity/prp-implement.md
@@ -133,10 +133,23 @@ git worktree list
 
 | Current State | Action |
 |---------------|--------|
-| In worktree | Use it (log: "Using worktree") |
-| On main, clean | Create branch: `git checkout -b feature/{plan-slug}` |
-| On main, dirty | STOP: "Stash or commit changes first" |
-| On feature branch | Use it (log: "Using existing branch") |
+| Already in a worktree | Use it (log: "Using existing worktree") |
+| On feature branch (not main) | Use it (log: "Using existing branch") |
+| On main | Create isolated worktree (see below) |
+
+**Worktree creation (when on main):**
+
+```bash
+BRANCH="feature/{plan-slug}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
+```
+
+After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
+The original working tree stays clean — other agents can work there simultaneously.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
 
 ### 2.3 Sync with Remote
 
@@ -148,7 +161,7 @@ git pull --rebase origin main 2>/dev/null || true
 **PHASE_2_CHECKPOINT:**
 
 - [ ] On correct branch (not main with uncommitted work)
-- [ ] Working directory ready
+- [ ] Working in isolated worktree (or existing feature branch)
 - [ ] Up to date with remote
 
 ---

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -201,7 +201,7 @@ mkdir -p .prp-output/state
 ```
 
 Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmatter:
-- step, total_steps, feature, plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle
+- step, total_steps, feature, plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle
 - use_ralph, ralph_max_iter, fix_severity, fast_plan, skip_plan, skip_review, no_pr, no_interact
 - issue_number, auto_merge, max_cycles
 - verify, qa_delegate, done
@@ -210,7 +210,7 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
-If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
+If `worktree_path` is non-empty: validate it starts with `/tmp/prp-worktree/` and the directory exists, then `cd` to it before resuming. Reject paths that don't match the prefix.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
@@ -273,18 +273,21 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 ```bash
 CURRENT=$(git branch --show-current)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed"; exit 1; }
 fi
 ```
 
@@ -293,7 +296,7 @@ Use **absolute paths** within the worktree for Edit/Write tool calls.
 Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
+**Failure**: worktree creation fails → falls back to `git checkout -b` (WORKTREE_PATH = empty). All guards STOP on unrecoverable errors.
 
 ---
 

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -63,6 +63,7 @@ If 1 plan → use it. If multiple → ask (or pick most recent in no-interact). 
 FEATURE = "{remaining text after flags, or title from plan file}"
 PLAN_PATH = "{from --prp-path, or TBD — set in Step 2}"
 BRANCH = "{TBD — set in Step 1}"
+WORKTREE_PATH = "{TBD — set in Step 1, empty if using existing branch}"
 PR_NUMBER = "{TBD — set in Step 5}"
 REVIEW_ARTIFACT = "{TBD — set in Step 6.1}"
 USE_RALPH = {true if --ralph}
@@ -264,17 +265,24 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ---
 
-### Step 1: CREATE BRANCH (skip if RESUME_FROM > 1)
+### Step 1: CREATE BRANCH + WORKTREE (skip if RESUME_FROM > 1)
 
-**Skip if**: already on a feature branch (not main/master).
+**Skip if**: already on a feature branch (not main/master) or already in a worktree.
 
 ```bash
 CURRENT=$(git branch --show-current)
-git checkout -b feature/{slug-from-FEATURE}
+BRANCH="feature/{slug-from-FEATURE}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
 ```
 
-**Variable update**: `BRANCH = feature/{slug}`
-**Failure**: dirty working dir on main → STOP, ask to stash/commit.
+All subsequent steps run inside the worktree. The original working tree stays clean.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
+
+**Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
+**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
 
 ---
 

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -210,13 +210,14 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
+If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
 **STATE UPDATE RULE**: After each step completes:
 1. Increment `step` to next step number
 2. Update `updated_at`
-3. Update new variable values (plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
+3. Update new variable values (plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
 4. Append completed step to table
 5. Append new artifacts
 
@@ -271,18 +272,28 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ```bash
 CURRENT=$(git branch --show-current)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 All subsequent steps run inside the worktree. The original working tree stays clean.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
+**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
 
 ---
 

--- a/adapters/claude-code/prp-cleanup.md
+++ b/adapters/claude-code/prp-cleanup.md
@@ -210,7 +210,7 @@ git branch -D {branch}
 
 **If still fails** (branch doesn't exist locally): Skip — already deleted.
 
-### 4.3 Delete Remote Branch
+### 4.4 Delete Remote Branch
 
 ```bash
 git push origin --delete {branch}

--- a/adapters/claude-code/prp-cleanup.md
+++ b/adapters/claude-code/prp-cleanup.md
@@ -189,10 +189,11 @@ Action: Delete local + remote
 
 ```bash
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
-if [ -d "$WORKTREE_PATH" ]; then
-    cd ~  # exit worktree before removing
-    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
-      git worktree remove --force "$WORKTREE_PATH"
+if [ -d "$WORKTREE_PATH" ] && [[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")"
+    git -C "$REPO_ROOT" worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_PATH" || \
+      echo "WARN: Could not remove worktree at $WORKTREE_PATH — run 'git worktree prune' manually."
 fi
 ```
 
@@ -219,13 +220,13 @@ git push origin --delete {branch}
 **If fails** (already deleted): Skip — already cleaned up.
 **If fails** (permission denied): WARN — "Cannot delete remote branch. Check permissions."
 
-### 4.4 Prune Remote References
+### 4.5 Prune Remote References
 
 ```bash
 git remote prune origin
 ```
 
-### 4.5 Remove Orphaned State Files
+### 4.6 Remove Orphaned State Files
 
 ```bash
 # Remove run-all state file if it refers to the cleaned branch

--- a/adapters/claude-code/prp-cleanup.md
+++ b/adapters/claude-code/prp-cleanup.md
@@ -185,7 +185,18 @@ Action: Delete local + remote
 
 **If `DRY_RUN`**: Show preview only, skip deletion.
 
-### 4.2 Delete Local Branch
+### 4.2 Remove Worktree (if exists)
+
+```bash
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+if [ -d "$WORKTREE_PATH" ]; then
+    cd ~  # exit worktree before removing
+    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git worktree remove --force "$WORKTREE_PATH"
+fi
+```
+
+### 4.3 Delete Local Branch
 
 ```bash
 git branch -d {branch}

--- a/adapters/claude-code/prp-implement.md
+++ b/adapters/claude-code/prp-implement.md
@@ -135,10 +135,23 @@ git worktree list
 
 | Current State | Action |
 |---------------|--------|
-| In worktree | Use it (log: "Using worktree") |
-| On main, clean | Create branch: `git checkout -b feature/{plan-slug}` |
-| On main, dirty | STOP: "Stash or commit changes first" |
-| On feature branch | Use it (log: "Using existing branch") |
+| Already in a worktree | Use it (log: "Using existing worktree") |
+| On feature branch (not main) | Use it (log: "Using existing branch") |
+| On main | Create isolated worktree (see below) |
+
+**Worktree creation (when on main):**
+
+```bash
+BRANCH="feature/{plan-slug}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
+```
+
+After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
+The original working tree stays clean — other agents can work there simultaneously.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
 
 ### 2.3 Sync with Remote
 
@@ -150,7 +163,7 @@ git pull --rebase origin main 2>/dev/null || true
 **PHASE_2_CHECKPOINT:**
 
 - [ ] On correct branch (not main with uncommitted work)
-- [ ] Working directory ready
+- [ ] Working in isolated worktree (or existing feature branch)
 - [ ] Up to date with remote
 
 ---

--- a/adapters/claude-code/prp-implement.md
+++ b/adapters/claude-code/prp-implement.md
@@ -137,25 +137,28 @@ git worktree list
 |---------------|--------|
 | Already in a worktree | Use it (log: "Using existing worktree") |
 | On feature branch (not main) | Use it (log: "Using existing branch") |
-| On main | Create isolated worktree (see below) |
+| On main, dirty | WARN: "Uncommitted changes on main will NOT be included in the worktree." Then proceed. |
+| On main, clean | Create isolated worktree (see below) |
 
 **Worktree creation (when on main):**
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    # Symlink .prp-output back to original repo so artifacts survive worktree removal
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed — artifacts would be lost on cleanup"; exit 1; }
 fi
 ```
 

--- a/adapters/claude-code/prp-implement.md
+++ b/adapters/claude-code/prp-implement.md
@@ -142,16 +142,27 @@ git worktree list
 **Worktree creation (when on main):**
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    # Symlink .prp-output back to original repo so artifacts survive worktree removal
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
 The original working tree stays clean — other agents can work there simultaneously.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 ### 2.3 Sync with Remote
 

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -212,13 +212,14 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
+If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
 **STATE UPDATE RULE**: After each step completes:
 1. Increment `step` to next step number
 2. Update `updated_at`
-3. Update new variable values (plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
+3. Update new variable values (plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
 4. Append completed step to table
 5. Append new artifacts
 
@@ -273,18 +274,28 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ```bash
 CURRENT=$(git branch --show-current)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 All subsequent steps run inside the worktree. The original working tree stays clean.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
+**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
 
 ---
 

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -203,7 +203,7 @@ mkdir -p .prp-output/state
 ```
 
 Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmatter:
-- step, total_steps, feature, plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle
+- step, total_steps, feature, plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle
 - use_ralph, ralph_max_iter, fix_severity, fast_plan, skip_plan, skip_review, no_pr, no_interact
 - issue_number, auto_merge, max_cycles
 - verify, qa_delegate, done
@@ -212,7 +212,7 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
-If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
+If `worktree_path` is non-empty: validate it starts with `/tmp/prp-worktree/` and the directory exists, then `cd` to it before resuming. Reject paths that don't match the prefix.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
@@ -275,18 +275,21 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 ```bash
 CURRENT=$(git branch --show-current)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed"; exit 1; }
 fi
 ```
 
@@ -295,7 +298,7 @@ Use **absolute paths** within the worktree for Edit/Write tool calls.
 Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
+**Failure**: worktree creation fails → falls back to `git checkout -b` (WORKTREE_PATH = empty). All guards STOP on unrecoverable errors.
 
 ---
 

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -65,6 +65,7 @@ If 1 plan → use it. If multiple → ask (or pick most recent in no-interact). 
 FEATURE = "{remaining text after flags, or title from plan file}"
 PLAN_PATH = "{from --prp-path, or TBD — set in Step 2}"
 BRANCH = "{TBD — set in Step 1}"
+WORKTREE_PATH = "{TBD — set in Step 1, empty if using existing branch}"
 PR_NUMBER = "{TBD — set in Step 5}"
 REVIEW_ARTIFACT = "{TBD — set in Step 6.1}"
 USE_RALPH = {true if --ralph}
@@ -266,17 +267,24 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ---
 
-### Step 1: CREATE BRANCH (skip if RESUME_FROM > 1)
+### Step 1: CREATE BRANCH + WORKTREE (skip if RESUME_FROM > 1)
 
-**Skip if**: already on a feature branch (not main/master).
+**Skip if**: already on a feature branch (not main/master) or already in a worktree.
 
 ```bash
 CURRENT=$(git branch --show-current)
-git checkout -b feature/{slug-from-FEATURE}
+BRANCH="feature/{slug-from-FEATURE}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
 ```
 
-**Variable update**: `BRANCH = feature/{slug}`
-**Failure**: dirty working dir on main → STOP, ask to stash/commit.
+All subsequent steps run inside the worktree. The original working tree stays clean.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
+
+**Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
+**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
 
 ---
 

--- a/adapters/codex/prp-cleanup/SKILL.md
+++ b/adapters/codex/prp-cleanup/SKILL.md
@@ -186,7 +186,18 @@ Action: Delete local + remote
 
 **If `DRY_RUN`**: Show preview only, skip deletion.
 
-### 4.2 Delete Local Branch
+### 4.2 Remove Worktree (if exists)
+
+```bash
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+if [ -d "$WORKTREE_PATH" ]; then
+    cd ~  # exit worktree before removing
+    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git worktree remove --force "$WORKTREE_PATH"
+fi
+```
+
+### 4.3 Delete Local Branch
 
 ```bash
 git branch -d {branch}

--- a/adapters/codex/prp-cleanup/SKILL.md
+++ b/adapters/codex/prp-cleanup/SKILL.md
@@ -190,10 +190,11 @@ Action: Delete local + remote
 
 ```bash
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
-if [ -d "$WORKTREE_PATH" ]; then
-    cd ~  # exit worktree before removing
-    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
-      git worktree remove --force "$WORKTREE_PATH"
+if [ -d "$WORKTREE_PATH" ] && [[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")"
+    git -C "$REPO_ROOT" worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_PATH" || \
+      echo "WARN: Could not remove worktree at $WORKTREE_PATH — run 'git worktree prune' manually."
 fi
 ```
 
@@ -220,13 +221,13 @@ git push origin --delete {branch}
 **If fails** (already deleted): Skip — already cleaned up.
 **If fails** (permission denied): WARN — "Cannot delete remote branch. Check permissions."
 
-### 4.4 Prune Remote References
+### 4.5 Prune Remote References
 
 ```bash
 git remote prune origin
 ```
 
-### 4.5 Remove Orphaned State Files
+### 4.6 Remove Orphaned State Files
 
 ```bash
 # Remove run-all state file if it refers to the cleaned branch

--- a/adapters/codex/prp-cleanup/SKILL.md
+++ b/adapters/codex/prp-cleanup/SKILL.md
@@ -211,7 +211,7 @@ git branch -D {branch}
 
 **If still fails** (branch doesn't exist locally): Skip — already deleted.
 
-### 4.3 Delete Remote Branch
+### 4.4 Delete Remote Branch
 
 ```bash
 git push origin --delete {branch}

--- a/adapters/codex/prp-implement/SKILL.md
+++ b/adapters/codex/prp-implement/SKILL.md
@@ -138,25 +138,28 @@ git worktree list
 |---------------|--------|
 | Already in a worktree | Use it (log: "Using existing worktree") |
 | On feature branch (not main) | Use it (log: "Using existing branch") |
-| On main | Create isolated worktree (see below) |
+| On main, dirty | WARN: "Uncommitted changes on main will NOT be included in the worktree." Then proceed. |
+| On main, clean | Create isolated worktree (see below) |
 
 **Worktree creation (when on main):**
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    # Symlink .prp-output back to original repo so artifacts survive worktree removal
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed — artifacts would be lost on cleanup"; exit 1; }
 fi
 ```
 

--- a/adapters/codex/prp-implement/SKILL.md
+++ b/adapters/codex/prp-implement/SKILL.md
@@ -136,10 +136,23 @@ git worktree list
 
 | Current State | Action |
 |---------------|--------|
-| In worktree | Use it (log: "Using worktree") |
-| On main, clean | Create branch: `git checkout -b feature/{plan-slug}` |
-| On main, dirty | STOP: "Stash or commit changes first" |
-| On feature branch | Use it (log: "Using existing branch") |
+| Already in a worktree | Use it (log: "Using existing worktree") |
+| On feature branch (not main) | Use it (log: "Using existing branch") |
+| On main | Create isolated worktree (see below) |
+
+**Worktree creation (when on main):**
+
+```bash
+BRANCH="feature/{plan-slug}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
+```
+
+After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
+The original working tree stays clean — other agents can work there simultaneously.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
 
 ### 2.3 Sync with Remote
 
@@ -151,7 +164,7 @@ git pull --rebase origin main 2>/dev/null || true
 **PHASE_2_CHECKPOINT:**
 
 - [ ] On correct branch (not main with uncommitted work)
-- [ ] Working directory ready
+- [ ] Working in isolated worktree (or existing feature branch)
 - [ ] Up to date with remote
 
 ---

--- a/adapters/codex/prp-implement/SKILL.md
+++ b/adapters/codex/prp-implement/SKILL.md
@@ -143,16 +143,27 @@ git worktree list
 **Worktree creation (when on main):**
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    # Symlink .prp-output back to original repo so artifacts survive worktree removal
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
 The original working tree stays clean — other agents can work there simultaneously.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 ### 2.3 Sync with Remote
 

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -66,6 +66,7 @@ If 1 plan → use it. If multiple → ask (or pick most recent in no-interact). 
 FEATURE = "{remaining text after flags, or title from plan file}"
 PLAN_PATH = "{from --prp-path, or TBD — set in Step 2}"
 BRANCH = "{TBD — set in Step 1}"
+WORKTREE_PATH = "{TBD — set in Step 1, empty if using existing branch}"
 PR_NUMBER = "{TBD — set in Step 5}"
 REVIEW_ARTIFACT = "{TBD — set in Step 6.1}"
 USE_RALPH = {true if --ralph}
@@ -267,17 +268,24 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ---
 
-### Step 1: CREATE BRANCH (skip if RESUME_FROM > 1)
+### Step 1: CREATE BRANCH + WORKTREE (skip if RESUME_FROM > 1)
 
-**Skip if**: already on a feature branch (not main/master).
+**Skip if**: already on a feature branch (not main/master) or already in a worktree.
 
 ```bash
 CURRENT=$(git branch --show-current)
-git checkout -b feature/{slug-from-FEATURE}
+BRANCH="feature/{slug-from-FEATURE}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
 ```
 
-**Variable update**: `BRANCH = feature/{slug}`
-**Failure**: dirty working dir on main → STOP, ask to stash/commit.
+All subsequent steps run inside the worktree. The original working tree stays clean.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
+
+**Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
+**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
 
 ---
 

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -204,7 +204,7 @@ mkdir -p .prp-output/state
 ```
 
 Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmatter:
-- step, total_steps, feature, plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle
+- step, total_steps, feature, plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle
 - use_ralph, ralph_max_iter, fix_severity, fast_plan, skip_plan, skip_review, no_pr, no_interact
 - issue_number, auto_merge, max_cycles
 - verify, qa_delegate, done
@@ -213,7 +213,7 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
-If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
+If `worktree_path` is non-empty: validate it starts with `/tmp/prp-worktree/` and the directory exists, then `cd` to it before resuming. Reject paths that don't match the prefix.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
@@ -276,18 +276,21 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 ```bash
 CURRENT=$(git branch --show-current)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed"; exit 1; }
 fi
 ```
 
@@ -296,7 +299,7 @@ Use **absolute paths** within the worktree for Edit/Write tool calls.
 Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
+**Failure**: worktree creation fails → falls back to `git checkout -b` (WORKTREE_PATH = empty). All guards STOP on unrecoverable errors.
 
 ---
 

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -213,13 +213,14 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
+If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
 **STATE UPDATE RULE**: After each step completes:
 1. Increment `step` to next step number
 2. Update `updated_at`
-3. Update new variable values (plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
+3. Update new variable values (plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
 4. Append completed step to table
 5. Append new artifacts
 
@@ -274,18 +275,28 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ```bash
 CURRENT=$(git branch --show-current)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 All subsequent steps run inside the worktree. The original working tree stays clean.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
+**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
 
 ---
 

--- a/adapters/gemini/cleanup.toml
+++ b/adapters/gemini/cleanup.toml
@@ -182,7 +182,18 @@ Action: Delete local + remote
 
 **If `DRY_RUN`**: Show preview only, skip deletion.
 
-### 4.2 Delete Local Branch
+### 4.2 Remove Worktree (if exists)
+
+```bash
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
+if [ -d "$WORKTREE_PATH" ]; then
+    cd ~  # exit worktree before removing
+    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \\
+      git worktree remove --force "$WORKTREE_PATH"
+fi
+```
+
+### 4.3 Delete Local Branch
 
 ```bash
 git branch -d {branch}

--- a/adapters/gemini/cleanup.toml
+++ b/adapters/gemini/cleanup.toml
@@ -186,10 +186,11 @@ Action: Delete local + remote
 
 ```bash
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
-if [ -d "$WORKTREE_PATH" ]; then
-    cd ~  # exit worktree before removing
-    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \\
-      git worktree remove --force "$WORKTREE_PATH"
+if [ -d "$WORKTREE_PATH" ] && [[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")"
+    git -C "$REPO_ROOT" worktree remove "$WORKTREE_PATH" 2>/dev/null || \\
+      git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_PATH" || \\
+      echo "WARN: Could not remove worktree at $WORKTREE_PATH — run 'git worktree prune' manually."
 fi
 ```
 
@@ -216,13 +217,13 @@ git push origin --delete {branch}
 **If fails** (already deleted): Skip — already cleaned up.
 **If fails** (permission denied): WARN — "Cannot delete remote branch. Check permissions."
 
-### 4.4 Prune Remote References
+### 4.5 Prune Remote References
 
 ```bash
 git remote prune origin
 ```
 
-### 4.5 Remove Orphaned State Files
+### 4.6 Remove Orphaned State Files
 
 ```bash
 # Remove run-all state file if it refers to the cleaned branch

--- a/adapters/gemini/cleanup.toml
+++ b/adapters/gemini/cleanup.toml
@@ -207,7 +207,7 @@ git branch -D {branch}
 
 **If still fails** (branch doesn't exist locally): Skip — already deleted.
 
-### 4.3 Delete Remote Branch
+### 4.4 Delete Remote Branch
 
 ```bash
 git push origin --delete {branch}

--- a/adapters/gemini/implement.toml
+++ b/adapters/gemini/implement.toml
@@ -132,10 +132,23 @@ git worktree list
 
 | Current State | Action |
 |---------------|--------|
-| In worktree | Use it (log: "Using worktree") |
-| On main, clean | Create branch: `git checkout -b feature/{plan-slug}` |
-| On main, dirty | STOP: "Stash or commit changes first" |
-| On feature branch | Use it (log: "Using existing branch") |
+| Already in a worktree | Use it (log: "Using existing worktree") |
+| On feature branch (not main) | Use it (log: "Using existing branch") |
+| On main | Create isolated worktree (see below) |
+
+**Worktree creation (when on main):**
+
+```bash
+BRANCH="feature/{plan-slug}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \\
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
+```
+
+After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
+The original working tree stays clean — other agents can work there simultaneously.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
 
 ### 2.3 Sync with Remote
 
@@ -147,7 +160,7 @@ git pull --rebase origin main 2>/dev/null || true
 **PHASE_2_CHECKPOINT:**
 
 - [ ] On correct branch (not main with uncommitted work)
-- [ ] Working directory ready
+- [ ] Working in isolated worktree (or existing feature branch)
 - [ ] Up to date with remote
 
 ---

--- a/adapters/gemini/implement.toml
+++ b/adapters/gemini/implement.toml
@@ -134,25 +134,28 @@ git worktree list
 |---------------|--------|
 | Already in a worktree | Use it (log: "Using existing worktree") |
 | On feature branch (not main) | Use it (log: "Using existing branch") |
-| On main | Create isolated worktree (see below) |
+| On main, dirty | WARN: "Uncommitted changes on main will NOT be included in the worktree." Then proceed. |
+| On main, clean | Create isolated worktree (see below) |
 
 **Worktree creation (when on main):**
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \\
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    # Symlink .prp-output back to original repo so artifacts survive worktree removal
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed — artifacts would be lost on cleanup"; exit 1; }
 fi
 ```
 

--- a/adapters/gemini/implement.toml
+++ b/adapters/gemini/implement.toml
@@ -139,16 +139,27 @@ git worktree list
 **Worktree creation (when on main):**
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \\
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    # Symlink .prp-output back to original repo so artifacts survive worktree removal
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
 The original working tree stays clean — other agents can work there simultaneously.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 ### 2.3 Sync with Remote
 

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -62,6 +62,7 @@ If 1 plan → use it. If multiple → ask (or pick most recent in no-interact). 
 FEATURE = "{remaining text after flags, or title from plan file}"
 PLAN_PATH = "{from --prp-path, or TBD — set in Step 2}"
 BRANCH = "{TBD — set in Step 1}"
+WORKTREE_PATH = "{TBD — set in Step 1, empty if using existing branch}"
 PR_NUMBER = "{TBD — set in Step 5}"
 REVIEW_ARTIFACT = "{TBD — set in Step 6.1}"
 USE_RALPH = {true if --ralph}
@@ -263,17 +264,24 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ---
 
-### Step 1: CREATE BRANCH (skip if RESUME_FROM > 1)
+### Step 1: CREATE BRANCH + WORKTREE (skip if RESUME_FROM > 1)
 
-**Skip if**: already on a feature branch (not main/master).
+**Skip if**: already on a feature branch (not main/master) or already in a worktree.
 
 ```bash
 CURRENT=$(git branch --show-current)
-git checkout -b feature/{slug-from-FEATURE}
+BRANCH="feature/{slug-from-FEATURE}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \\
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
 ```
 
-**Variable update**: `BRANCH = feature/{slug}`
-**Failure**: dirty working dir on main → STOP, ask to stash/commit.
+All subsequent steps run inside the worktree. The original working tree stays clean.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
+
+**Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
+**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
 
 ---
 

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -200,7 +200,7 @@ mkdir -p .prp-output/state
 ```
 
 Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmatter:
-- step, total_steps, feature, plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle
+- step, total_steps, feature, plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle
 - use_ralph, ralph_max_iter, fix_severity, fast_plan, skip_plan, skip_review, no_pr, no_interact
 - issue_number, auto_merge, max_cycles
 - verify, qa_delegate, done
@@ -209,7 +209,7 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
-If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
+If `worktree_path` is non-empty: validate it starts with `/tmp/prp-worktree/` and the directory exists, then `cd` to it before resuming. Reject paths that don't match the prefix.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
@@ -272,18 +272,21 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 ```bash
 CURRENT=$(git branch --show-current)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \\
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed"; exit 1; }
 fi
 ```
 
@@ -292,7 +295,7 @@ Use **absolute paths** within the worktree for Edit/Write tool calls.
 Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
+**Failure**: worktree creation fails → falls back to `git checkout -b` (WORKTREE_PATH = empty). All guards STOP on unrecoverable errors.
 
 ---
 

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -209,13 +209,14 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
+If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
 **STATE UPDATE RULE**: After each step completes:
 1. Increment `step` to next step number
 2. Update `updated_at`
-3. Update new variable values (plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
+3. Update new variable values (plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
 4. Append completed step to table
 5. Append new artifacts
 
@@ -270,18 +271,28 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ```bash
 CURRENT=$(git branch --show-current)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \\
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 All subsequent steps run inside the worktree. The original working tree stays clean.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
+**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
 
 ---
 

--- a/adapters/opencode/cleanup.md
+++ b/adapters/opencode/cleanup.md
@@ -209,7 +209,7 @@ git branch -D {branch}
 
 **If still fails** (branch doesn't exist locally): Skip — already deleted.
 
-### 4.3 Delete Remote Branch
+### 4.4 Delete Remote Branch
 
 ```bash
 git push origin --delete {branch}

--- a/adapters/opencode/cleanup.md
+++ b/adapters/opencode/cleanup.md
@@ -188,10 +188,11 @@ Action: Delete local + remote
 
 ```bash
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
-if [ -d "$WORKTREE_PATH" ]; then
-    cd ~  # exit worktree before removing
-    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
-      git worktree remove --force "$WORKTREE_PATH"
+if [ -d "$WORKTREE_PATH" ] && [[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")"
+    git -C "$REPO_ROOT" worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_PATH" || \
+      echo "WARN: Could not remove worktree at $WORKTREE_PATH — run 'git worktree prune' manually."
 fi
 ```
 
@@ -218,13 +219,13 @@ git push origin --delete {branch}
 **If fails** (already deleted): Skip — already cleaned up.
 **If fails** (permission denied): WARN — "Cannot delete remote branch. Check permissions."
 
-### 4.4 Prune Remote References
+### 4.5 Prune Remote References
 
 ```bash
 git remote prune origin
 ```
 
-### 4.5 Remove Orphaned State Files
+### 4.6 Remove Orphaned State Files
 
 ```bash
 # Remove run-all state file if it refers to the cleaned branch

--- a/adapters/opencode/cleanup.md
+++ b/adapters/opencode/cleanup.md
@@ -184,7 +184,18 @@ Action: Delete local + remote
 
 **If `DRY_RUN`**: Show preview only, skip deletion.
 
-### 4.2 Delete Local Branch
+### 4.2 Remove Worktree (if exists)
+
+```bash
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+if [ -d "$WORKTREE_PATH" ]; then
+    cd ~  # exit worktree before removing
+    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git worktree remove --force "$WORKTREE_PATH"
+fi
+```
+
+### 4.3 Delete Local Branch
 
 ```bash
 git branch -d {branch}

--- a/adapters/opencode/implement.md
+++ b/adapters/opencode/implement.md
@@ -136,25 +136,28 @@ git worktree list
 |---------------|--------|
 | Already in a worktree | Use it (log: "Using existing worktree") |
 | On feature branch (not main) | Use it (log: "Using existing branch") |
-| On main | Create isolated worktree (see below) |
+| On main, dirty | WARN: "Uncommitted changes on main will NOT be included in the worktree." Then proceed. |
+| On main, clean | Create isolated worktree (see below) |
 
 **Worktree creation (when on main):**
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    # Symlink .prp-output back to original repo so artifacts survive worktree removal
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed — artifacts would be lost on cleanup"; exit 1; }
 fi
 ```
 

--- a/adapters/opencode/implement.md
+++ b/adapters/opencode/implement.md
@@ -141,16 +141,27 @@ git worktree list
 **Worktree creation (when on main):**
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    # Symlink .prp-output back to original repo so artifacts survive worktree removal
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
 The original working tree stays clean — other agents can work there simultaneously.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 ### 2.3 Sync with Remote
 

--- a/adapters/opencode/implement.md
+++ b/adapters/opencode/implement.md
@@ -134,10 +134,23 @@ git worktree list
 
 | Current State | Action |
 |---------------|--------|
-| In worktree | Use it (log: "Using worktree") |
-| On main, clean | Create branch: `git checkout -b feature/{plan-slug}` |
-| On main, dirty | STOP: "Stash or commit changes first" |
-| On feature branch | Use it (log: "Using existing branch") |
+| Already in a worktree | Use it (log: "Using existing worktree") |
+| On feature branch (not main) | Use it (log: "Using existing branch") |
+| On main | Create isolated worktree (see below) |
+
+**Worktree creation (when on main):**
+
+```bash
+BRANCH="feature/{plan-slug}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
+```
+
+After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
+The original working tree stays clean — other agents can work there simultaneously.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
 
 ### 2.3 Sync with Remote
 
@@ -149,7 +162,7 @@ git pull --rebase origin main 2>/dev/null || true
 **PHASE_2_CHECKPOINT:**
 
 - [ ] On correct branch (not main with uncommitted work)
-- [ ] Working directory ready
+- [ ] Working in isolated worktree (or existing feature branch)
 - [ ] Up to date with remote
 
 ---

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -202,7 +202,7 @@ mkdir -p .prp-output/state
 ```
 
 Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmatter:
-- step, total_steps, feature, plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle
+- step, total_steps, feature, plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle
 - use_ralph, ralph_max_iter, fix_severity, fast_plan, skip_plan, skip_review, no_pr, no_interact
 - issue_number, auto_merge, max_cycles
 - verify, qa_delegate, done
@@ -211,7 +211,7 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
-If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
+If `worktree_path` is non-empty: validate it starts with `/tmp/prp-worktree/` and the directory exists, then `cd` to it before resuming. Reject paths that don't match the prefix.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
@@ -274,18 +274,21 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 ```bash
 CURRENT=$(git branch --show-current)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed"; exit 1; }
 fi
 ```
 
@@ -294,7 +297,7 @@ Use **absolute paths** within the worktree for Edit/Write tool calls.
 Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
+**Failure**: worktree creation fails → falls back to `git checkout -b` (WORKTREE_PATH = empty). All guards STOP on unrecoverable errors.
 
 ---
 

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -64,6 +64,7 @@ If 1 plan → use it. If multiple → ask (or pick most recent in no-interact). 
 FEATURE = "{remaining text after flags, or title from plan file}"
 PLAN_PATH = "{from --prp-path, or TBD — set in Step 2}"
 BRANCH = "{TBD — set in Step 1}"
+WORKTREE_PATH = "{TBD — set in Step 1, empty if using existing branch}"
 PR_NUMBER = "{TBD — set in Step 5}"
 REVIEW_ARTIFACT = "{TBD — set in Step 6.1}"
 USE_RALPH = {true if --ralph}
@@ -265,17 +266,24 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ---
 
-### Step 1: CREATE BRANCH (skip if RESUME_FROM > 1)
+### Step 1: CREATE BRANCH + WORKTREE (skip if RESUME_FROM > 1)
 
-**Skip if**: already on a feature branch (not main/master).
+**Skip if**: already on a feature branch (not main/master) or already in a worktree.
 
 ```bash
 CURRENT=$(git branch --show-current)
-git checkout -b feature/{slug-from-FEATURE}
+BRANCH="feature/{slug-from-FEATURE}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
 ```
 
-**Variable update**: `BRANCH = feature/{slug}`
-**Failure**: dirty working dir on main → STOP, ask to stash/commit.
+All subsequent steps run inside the worktree. The original working tree stays clean.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
+
+**Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
+**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
 
 ---
 

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -211,13 +211,14 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
+If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
 **STATE UPDATE RULE**: After each step completes:
 1. Increment `step` to next step number
 2. Update `updated_at`
-3. Update new variable values (plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
+3. Update new variable values (plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
 4. Append completed step to table
 5. Append new artifacts
 
@@ -272,18 +273,28 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ```bash
 CURRENT=$(git branch --show-current)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 All subsequent steps run inside the worktree. The original working tree stays clean.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
+**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
 
 ---
 

--- a/prompts/cleanup.md
+++ b/prompts/cleanup.md
@@ -205,7 +205,7 @@ git branch -D {branch}
 
 **If still fails** (branch doesn't exist locally): Skip — already deleted.
 
-### 4.3 Delete Remote Branch
+### 4.4 Delete Remote Branch
 
 ```bash
 git push origin --delete {branch}

--- a/prompts/cleanup.md
+++ b/prompts/cleanup.md
@@ -180,7 +180,18 @@ Action: Delete local + remote
 
 **If `DRY_RUN`**: Show preview only, skip deletion.
 
-### 4.2 Delete Local Branch
+### 4.2 Remove Worktree (if exists)
+
+```bash
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+if [ -d "$WORKTREE_PATH" ]; then
+    cd ~  # exit worktree before removing
+    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git worktree remove --force "$WORKTREE_PATH"
+fi
+```
+
+### 4.3 Delete Local Branch
 
 ```bash
 git branch -d {branch}

--- a/prompts/cleanup.md
+++ b/prompts/cleanup.md
@@ -184,10 +184,11 @@ Action: Delete local + remote
 
 ```bash
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
-if [ -d "$WORKTREE_PATH" ]; then
-    cd ~  # exit worktree before removing
-    git worktree remove "$WORKTREE_PATH" 2>/dev/null || \
-      git worktree remove --force "$WORKTREE_PATH"
+if [ -d "$WORKTREE_PATH" ] && [[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]]; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$HOME")"
+    git -C "$REPO_ROOT" worktree remove "$WORKTREE_PATH" 2>/dev/null || \
+      git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_PATH" || \
+      echo "WARN: Could not remove worktree at $WORKTREE_PATH — run 'git worktree prune' manually."
 fi
 ```
 
@@ -214,13 +215,13 @@ git push origin --delete {branch}
 **If fails** (already deleted): Skip — already cleaned up.
 **If fails** (permission denied): WARN — "Cannot delete remote branch. Check permissions."
 
-### 4.4 Prune Remote References
+### 4.5 Prune Remote References
 
 ```bash
 git remote prune origin
 ```
 
-### 4.5 Remove Orphaned State Files
+### 4.6 Remove Orphaned State Files
 
 ```bash
 # Remove run-all state file if it refers to the cleaned branch

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -132,25 +132,28 @@ git worktree list
 |---------------|--------|
 | Already in a worktree | Use it (log: "Using existing worktree") |
 | On feature branch (not main) | Use it (log: "Using existing branch") |
-| On main | Create isolated worktree (see below) |
+| On main, dirty | WARN: "Uncommitted changes on main will NOT be included in the worktree." Then proceed. |
+| On main, clean | Create isolated worktree (see below) |
 
 **Worktree creation (when on main):**
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    # Symlink .prp-output back to original repo so artifacts survive worktree removal
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed — artifacts would be lost on cleanup"; exit 1; }
 fi
 ```
 

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -130,10 +130,23 @@ git worktree list
 
 | Current State | Action |
 |---------------|--------|
-| In worktree | Use it (log: "Using worktree") |
-| On main, clean | Create branch: `git checkout -b feature/{plan-slug}` |
-| On main, dirty | STOP: "Stash or commit changes first" |
-| On feature branch | Use it (log: "Using existing branch") |
+| Already in a worktree | Use it (log: "Using existing worktree") |
+| On feature branch (not main) | Use it (log: "Using existing branch") |
+| On main | Create isolated worktree (see below) |
+
+**Worktree creation (when on main):**
+
+```bash
+BRANCH="feature/{plan-slug}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
+```
+
+After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
+The original working tree stays clean — other agents can work there simultaneously.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
 
 ### 2.3 Sync with Remote
 
@@ -145,7 +158,7 @@ git pull --rebase origin main 2>/dev/null || true
 **PHASE_2_CHECKPOINT:**
 
 - [ ] On correct branch (not main with uncommitted work)
-- [ ] Working directory ready
+- [ ] Working in isolated worktree (or existing feature branch)
 - [ ] Up to date with remote
 
 ---

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -137,16 +137,27 @@ git worktree list
 **Worktree creation (when on main):**
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{plan-slug}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    # Symlink .prp-output back to original repo so artifacts survive worktree removal
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 After this step, ALL subsequent operations (edits, commits, builds) happen inside the worktree.
 The original working tree stays clean — other agents can work there simultaneously.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 ### 2.3 Sync with Remote
 

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -198,7 +198,7 @@ mkdir -p .prp-output/state
 ```
 
 Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmatter:
-- step, total_steps, feature, plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle
+- step, total_steps, feature, plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle
 - use_ralph, ralph_max_iter, fix_severity, fast_plan, skip_plan, skip_review, no_pr, no_interact
 - issue_number, auto_merge, max_cycles
 - verify, qa_delegate, done
@@ -207,7 +207,7 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
-If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
+If `worktree_path` is non-empty: validate it starts with `/tmp/prp-worktree/` and the directory exists, then `cd` to it before resuming. Reject paths that don't match the prefix.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
@@ -270,18 +270,21 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 ```bash
 CURRENT=$(git branch --show-current)
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+[ -n "$REPO_ROOT" ] || { echo "STOP: not inside a git repository."; exit 1; }
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+[[ "$WORKTREE_PATH" == /tmp/prp-worktree/* ]] || { echo "STOP: invalid worktree path"; exit 1; }
+mkdir -p /tmp/prp-worktree
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
   git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
-    echo "Worktree creation failed — falling back to checkout"
-    git checkout -b "$BRANCH"
+    echo "FALLBACK: Worktree creation failed — using checkout-b in $(pwd)"
+    git checkout -b "$BRANCH" || { echo "STOP: cannot create branch $BRANCH"; exit 1; }
     WORKTREE_PATH=""
   }
 if [ -n "$WORKTREE_PATH" ]; then
-    cd "$WORKTREE_PATH"
-    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    cd "$WORKTREE_PATH" || { echo "STOP: cannot enter worktree"; git worktree remove "$WORKTREE_PATH" 2>/dev/null; exit 1; }
     mkdir -p "$REPO_ROOT/.prp-output"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output" || { echo "STOP: symlink failed"; exit 1; }
 fi
 ```
 
@@ -290,7 +293,7 @@ Use **absolute paths** within the worktree for Edit/Write tool calls.
 Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
+**Failure**: worktree creation fails → falls back to `git checkout -b` (WORKTREE_PATH = empty). All guards STOP on unrecoverable errors.
 
 ---
 

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -60,6 +60,7 @@ If 1 plan → use it. If multiple → ask (or pick most recent in no-interact). 
 FEATURE = "{remaining text after flags, or title from plan file}"
 PLAN_PATH = "{from --prp-path, or TBD — set in Step 2}"
 BRANCH = "{TBD — set in Step 1}"
+WORKTREE_PATH = "{TBD — set in Step 1, empty if using existing branch}"
 PR_NUMBER = "{TBD — set in Step 5}"
 REVIEW_ARTIFACT = "{TBD — set in Step 6.1}"
 USE_RALPH = {true if --ralph}
@@ -261,17 +262,24 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ---
 
-### Step 1: CREATE BRANCH (skip if RESUME_FROM > 1)
+### Step 1: CREATE BRANCH + WORKTREE (skip if RESUME_FROM > 1)
 
-**Skip if**: already on a feature branch (not main/master).
+**Skip if**: already on a feature branch (not main/master) or already in a worktree.
 
 ```bash
 CURRENT=$(git branch --show-current)
-git checkout -b feature/{slug-from-FEATURE}
+BRANCH="feature/{slug-from-FEATURE}"
+WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+cd "$WORKTREE_PATH"
 ```
 
-**Variable update**: `BRANCH = feature/{slug}`
-**Failure**: dirty working dir on main → STOP, ask to stash/commit.
+All subsequent steps run inside the worktree. The original working tree stays clean.
+Use **absolute paths** within the worktree for Edit/Write tool calls.
+
+**Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
+**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
 
 ---
 

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -207,13 +207,14 @@ Write `.prp-output/state/run-all.state.md` using Bash heredoc with YAML frontmat
 - Completed Steps table, Artifacts section, Error Log
 
 On `--resume`: restore ALL variables from state file. Set `RESUME_FROM = step` from frontmatter.
+If `worktree_path` is non-empty and the directory exists, `cd` to it before resuming.
 
 **STATE FILE I/O RULE**: Always use **Bash with heredoc** (`cat > file << 'EOF'`) to create and update state and lock files in `.prp-output/state/`. These are machine-generated tracking files, not source code.
 
 **STATE UPDATE RULE**: After each step completes:
 1. Increment `step` to next step number
 2. Update `updated_at`
-3. Update new variable values (plan_path, branch, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
+3. Update new variable values (plan_path, branch, worktree_path, pr_number, review_artifact, review_verdict, review_cycle, pending_skipped, all_skipped, skipped_count)
 4. Append completed step to table
 5. Append new artifacts
 
@@ -268,18 +269,28 @@ If `--prp-path` or `--skip-plan` already provided → skip smart detection (user
 
 ```bash
 CURRENT=$(git branch --show-current)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="feature/{slug-from-FEATURE}"
 WORKTREE_PATH="/tmp/prp-worktree/$(whoami)-${BRANCH//\//-}"
 git worktree add "$WORKTREE_PATH" -b "$BRANCH" main 2>/dev/null || \
-  git worktree add "$WORKTREE_PATH" "$BRANCH"
-cd "$WORKTREE_PATH"
+  git worktree add "$WORKTREE_PATH" "$BRANCH" 2>/dev/null || {
+    echo "Worktree creation failed — falling back to checkout"
+    git checkout -b "$BRANCH"
+    WORKTREE_PATH=""
+  }
+if [ -n "$WORKTREE_PATH" ]; then
+    cd "$WORKTREE_PATH"
+    ln -sfn "$REPO_ROOT/.prp-output" "$WORKTREE_PATH/.prp-output"
+    mkdir -p "$REPO_ROOT/.prp-output"
+fi
 ```
 
 All subsequent steps run inside the worktree. The original working tree stays clean.
 Use **absolute paths** within the worktree for Edit/Write tool calls.
+Artifacts (`.prp-output/`) are symlinked to the original repo — they persist after worktree removal.
 
 **Variable update**: `BRANCH = feature/{slug}`, `WORKTREE_PATH = /tmp/prp-worktree/...`
-**Failure**: worktree creation fails → fall back to `git checkout -b` on current tree.
+**Failure**: worktree creation fails → falls back to `git checkout -b` on current tree (WORKTREE_PATH = empty).
 
 ---
 


### PR DESCRIPTION
## Summary
PRP implement + run-all now auto-create a `git worktree` when starting on main, instead of `git checkout -b` on the shared working tree. Agents get isolated copies — no more mixed commits, stash conflicts, or branch clobbering.

## Changes
- **implement.md** Phase 2: `git worktree add` instead of `git checkout -b`
- **run-all.md** Step 1: same + `WORKTREE_PATH` state variable for resume
- **cleanup.md** Phase 4: `git worktree remove` before branch deletion
- All 15 adapters regenerated (5 tools × 3 commands)

## How it works
```
Agent on main → git worktree add /tmp/prp-worktree/{user}-feature-{slug}
             → all edits in worktree (absolute paths)
             → commit + push from worktree
             → PR created
             → cleanup removes worktree + branch
```

## Coverage
| Path | Covered? |
|------|----------|
| prp-implement | ✅ auto-worktree |
| prp-run-all | ✅ auto-worktree |
| delegate-dev (uses PRP) | ✅ inherits |
| dev-task scores (uses PRP) | ✅ inherits |
| orchestrate (uses PRP) | ✅ inherits |
| ping/ask (direct) | ❌ convention only (CLAUDE.md rule) |
| manual tmux | ❌ convention only |

## Test plan
- [ ] `prp-run-all` from main → creates worktree, edits there, PR from worktree
- [ ] Two agents run prp-implement simultaneously → separate worktrees, no conflict
- [ ] `prp-cleanup` after merge → worktree removed
- [ ] Resume (--resume) → finds worktree path from state
- [ ] Already on feature branch → no worktree (uses existing)

Closes gobikom/agent-devops#225

🤖 Generated with [Claude Code](https://claude.com/claude-code)