### PR TITLE
chore: gitignore results/, ψ/, and .prp symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,12 @@ AGENTS.md
 
 # PRP Framework - local clone (not a submodule)
 .prp/
+.prp
+
+# Runtime output
+results/
+
+# Oracle/memory artifacts
+ψ/
 
 !AGENTS.md


### PR DESCRIPTION
## Summary
- Add `results/`, `ψ/`, and `.prp` (symlink) to .gitignore
- These runtime artifacts were cluttering `git status` — no code changes

## Test plan
- [x] `git status` shows clean working tree after commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)