### PR TITLE
fix: skip per-repo prp-core-runner when global install exists

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -222,6 +222,11 @@ mkdir -p "$PROJECT_DIR/.claude/skills"
 for skill_dir in "$FRAMEWORK_DIR/adapters/claude-code-skills"/*; do
     if [ -d "$skill_dir" ]; then
         skill_name=$(basename "$skill_dir")
+        # Skip prp-core-runner if already installed globally (avoid double-skill)
+        if [ "$skill_name" = "prp-core-runner" ] && [ -d "$HOME/.claude/skills/prp-core-runner" ]; then
+            echo -e "${GREEN}  ✅ Skipping prp-core-runner — already installed globally.${NC}"
+            continue
+        fi
         if install_directory "$skill_dir" "$PROJECT_DIR/.claude/skills/$skill_name" "Claude Code Skill: $skill_name"; then
             USED_SYMLINKS=true
         else


### PR DESCRIPTION
## Summary
- Skip creating per-repo `.claude/skills/prp-core-runner` symlink when global `~/.claude/skills/prp-core-runner` exists (installed via `soul-install-all`)
- Avoids Claude Code showing `prp-core-runner` skill twice ("double skills")
- Falls back to per-repo install when global is absent (non-openclaw environments)

## Test Plan
- [x] Run `install.sh` with global present → prints "Skipping prp-core-runner — already installed globally." and skips
- [x] Run `install.sh` without global → installs per-repo symlink (fallback)
- [x] After cleanup: `find ~/repos/ -path "*/.claude/skills/prp-core-runner" -type l | wc -l` = 0
- [x] `ls ~/.claude/skills/prp-core-runner/SKILL.md` exists and valid

Fixes gobikom/agent-devops#252

🤖 Generated with [Claude Code](https://claude.com/claude-code)