### PR TITLE
fix(run-all): use safe-merge as default merge command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ Every major version release MUST include a `docs/migration/vX.0-to-vY.0.md` file
 
 ## [Unreleased]
 
+## [2.11.0] — 2026-05-27
+
+**Token optimization tools** — 4 helper scripts that reduce ~99K tokens per run-all cycle by optimizing I/O boundaries. Inspired by code-knowledge-mcp (ck) and rtk (Rust Token Killer) patterns. All changes go through `prompts/*.md` → `generate-adapters.py` → all 6 adapters auto-updated.
+
+### Added
+
+- **prp-explore** (`prompts/plan.md` Phase 2.0) — call ck_onboard/ck_query/ck_impact before Explore agent; scope file reads to 3-5 ck-identified files instead of 15-20; graceful fallback if ck unavailable
+- **prp-validate** (`scripts/prp-validate.sh`) — parallel execution of type-check/lint/test/build with compact JSON output (~270 tokens vs ~14K raw); auto-detect runner (bun/pnpm/npm/python/cargo/go); configurable timeout via `PRP_VALIDATE_TIMEOUT`
+- **prp-diff** (`scripts/prp-diff.sh`) — structural diff summary for review agents (~580 tokens vs ~27K full diff); shows modified/created/deleted files with hunk context; full BRE escaping for filenames
+- **prp-state** (`scripts/prp-state.sh`) — compact CLI for run-all state management (get/set/summary/check-gate); awk-based YAML mutation (safe for `|`, `&`, regex chars); ~24 tokens per state read vs ~91 for full file
+- **install.sh** — auto-installs helper scripts to `.prp/scripts/` via symlink with copy fallback
+- `prompts/implement.md` Phase 4.1, 4.3 — prp-validate integration with fallback
+- `prompts/review-agents.md`, `prompts/review.md` Phase 1.3 — prp-diff integration
+- `prompts/run-all.md` STATE UPDATE RULE — prp-state integration with fallback
+
 ## [2.10.0] — 2026-05-24
 
 **thClaws adapter** — 6th adapter added for the thClaws multi-provider agent harness. Generates SKILL.md files (same format as Codex adapter) installed to `.thclaws/skills/prp-*/`. Enables PRP workflows via Claude subscription (Agent SDK) or Codex subscription (ChatGPT) through thClaws without API keys.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The core philosophy: every task follows the same loop — **prompt** the AI with
 ✅ **Quality Built-in** - TDD approach, conditional design docs, pre-commit checks, security/performance validation
 ✅ **100% Workflow Parity** - 32 commands across all 6 adapters (22 core + 4 marketing + 5 bot + 1 meta), auto-generated from canonical prompts to guarantee zero drift
 ✅ **Auto-Generation** - Single source of truth in `prompts/` — edit once, generate all 6 adapters with `scripts/generate-adapters.py`
+✅ **Token Optimization** - Helper scripts (prp-validate, prp-diff, prp-state) reduce ~99K tokens per run-all cycle via compact output, parallel execution, and structural diffs
 ✅ **Monorepo Support** - Auto-detects pnpm workspaces, Turborepo, Nx, Lerna. `--package` flag scopes plan/implement/run-all to a specific package
 ✅ **31 Specialized Agents** - Development, security, marketing, sales, strategy, and business operations agents
 ✅ **Beyond Code** - Marketing automation, AI Bot design, sales enablement, and business strategy command packs
@@ -253,6 +254,11 @@ prp-framework/
 ├── docs/                       # Documentation
 │   └── SCRIPTS-REFERENCE.md   # Detailed script docs
 ├── scripts/                    # Installation & utility scripts
+│   ├── install.sh             # Install PRP to target project
+│   ├── generate-adapters.py   # Generate all 6 adapters from prompts/
+│   ├── prp-validate.sh        # Parallel validation with compact JSON output
+│   ├── prp-diff.sh            # Structural diff for review (compact markdown)
+│   └── prp-state.sh           # Compact state management for run-all
 └── LICENSE
 ```
 

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -640,10 +640,10 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 #### 8.1 Merge
 
 ```bash
-gh pr merge {PR_NUMBER} --squash --delete-branch
+safe-merge {PR_NUMBER} --squash
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+`safe-merge` wraps `gh pr merge` with CI-green gate and review-artifact gate. If `safe-merge` is not in `$PATH`, fall back to `gh pr merge {PR_NUMBER} --squash --delete-branch`.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -642,10 +642,10 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 #### 8.1 Merge
 
 ```bash
-gh pr merge {PR_NUMBER} --squash --delete-branch
+safe-merge {PR_NUMBER} --squash
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+`safe-merge` wraps `gh pr merge` with CI-green gate and review-artifact gate. If `safe-merge` is not in `$PATH`, fall back to `gh pr merge {PR_NUMBER} --squash --delete-branch`.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -643,10 +643,10 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 #### 8.1 Merge
 
 ```bash
-gh pr merge {PR_NUMBER} --squash --delete-branch
+safe-merge {PR_NUMBER} --squash
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+`safe-merge` wraps `gh pr merge` with CI-green gate and review-artifact gate. If `safe-merge` is not in `$PATH`, fall back to `gh pr merge {PR_NUMBER} --squash --delete-branch`.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -639,10 +639,10 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 #### 8.1 Merge
 
 ```bash
-gh pr merge {PR_NUMBER} --squash --delete-branch
+safe-merge {PR_NUMBER} --squash
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+`safe-merge` wraps `gh pr merge` with CI-green gate and review-artifact gate. If `safe-merge` is not in `$PATH`, fall back to `gh pr merge {PR_NUMBER} --squash --delete-branch`.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -641,10 +641,10 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 #### 8.1 Merge
 
 ```bash
-gh pr merge {PR_NUMBER} --squash --delete-branch
+safe-merge {PR_NUMBER} --squash
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+`safe-merge` wraps `gh pr merge` with CI-green gate and review-artifact gate. If `safe-merge` is not in `$PATH`, fall back to `gh pr merge {PR_NUMBER} --squash --delete-branch`.
 
 | Result | Action |
 |--------|--------|

--- a/adapters/thclaws/prp-run-all/SKILL.md
+++ b/adapters/thclaws/prp-run-all/SKILL.md
@@ -643,10 +643,10 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 #### 8.1 Merge
 
 ```bash
-gh pr merge {PR_NUMBER} --squash --delete-branch
+safe-merge {PR_NUMBER} --squash
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+`safe-merge` wraps `gh pr merge` with CI-green gate and review-artifact gate. If `safe-merge` is not in `$PATH`, fall back to `gh pr merge {PR_NUMBER} --squash --delete-branch`.
 
 | Result | Action |
 |--------|--------|

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -637,10 +637,10 @@ gh pr view {PR_NUMBER} --json state,mergeable --jq '{state: .state, mergeable: .
 #### 8.1 Merge
 
 ```bash
-gh pr merge {PR_NUMBER} --squash --delete-branch
+safe-merge {PR_NUMBER} --squash
 ```
 
-> **Tip (optional, workspace-dependent)**: If `safe-merge` is in `$PATH`, prefer it — it wraps `gh pr merge` with a CI-green gate (blocks FAIL/PENDING/UNKNOWN), an audit log, AND default-on local cleanup (checkout default branch, pull, delete merged branch, prune stale remote-tracking refs). Useful on private repos where server-side branch protection is not available. It accepts all the same flags; add `--no-cleanup` to skip the local cleanup step. Example: `safe-merge {PR_NUMBER} --squash --delete-branch`. If `safe-merge` is not installed, continue to use the default `gh pr merge` command above.
+`safe-merge` wraps `gh pr merge` with CI-green gate and review-artifact gate. If `safe-merge` is not in `$PATH`, fall back to `gh pr merge {PR_NUMBER} --squash --delete-branch`.
 
 | Result | Action |
 |--------|--------|


### PR DESCRIPTION
## Summary

Step 8.1 now uses `safe-merge` as default instead of `gh pr merge`.
Falls back to `gh pr merge` if safe-merge not in PATH.

Aligns with Safe-Merge Hard Rule in ~/.claude/CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)