### PR TITLE
fix: change default install preset from minimal to standard

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,7 +44,7 @@ elif [ -f "$PROJECT_DIR/.claude/prp-preset" ]; then
     PRESET=$(cat "$PROJECT_DIR/.claude/prp-preset" 2>/dev/null)
     echo "Using saved preset: $PRESET (from .claude/prp-preset)"
 else
-    PRESET="minimal"
+    PRESET="standard"
 fi
 
 echo "Framework directory: $FRAMEWORK_DIR"


### PR DESCRIPTION
Default preset: minimal → standard (23 commands). Use --minimal to opt in to 9-command mode.