### PR TITLE
feat(run-all): mechanical review-artifact gate (Step 6.2.0)

### DIFF
--- a/.prp-output/reviews/pr-107-agents-review.md
+++ b/.prp-output/reviews/pr-107-agents-review.md
@@ -1,0 +1,35 @@
+---
+pr: 107
+title: "feat(run-all): mechanical review-artifact gate (Step 6.2.0)"
+author: "gobikom"
+reviewed: 2026-06-12T01:00:00+07:00
+verdict: READY TO MERGE
+agents: [code-reviewer (bash/bats correctness), code-reviewer (adversarial bypass-hunting), code-reviewer (round-3 targeted)]
+---
+
+# PR #107 — Multi-Agent Review
+
+**Implementer:** PSak (Self-Implementer Protocol). Fixes agent-devops#534.
+
+## Round 1 (2 lenses) — 3 critical + 3 important
+| Sev | Finding | Fix |
+|-----|---------|-----|
+| CRIT | historical zero-line whitewashed later NEEDS FIXES (false pass — the exact #534 class) | position-based GOOD_RE/BAD_RE; pass requires last-good > last-bad |
+| CRIT | no bats for that scenario | added (exit 4) |
+| CRIT | re-verify tier mismatch broke fix-loop (stale agents artifact found before fresh single re-verify) | TIER_FLAG empty when REVIEW_CYCLE>1 + newest-across-globs selection; bats added |
+| IMP | miss counter ephemeral (lost on compact/--resume) | durable `prp-state.sh set review_miss_count` |
+| IMP | "0/0/0 + 5 suggestion" passed gate | BAD_RE covers nonzero suggestion(s); bats added |
+| IMP | stat failure → undocumented exit | both arms silenced + explicit exit-1 mapping |
+
+Bonus round-1 catch (process): adapters were stale at round-1 content — regenerated via generate-adapters.py (6 platforms).
+
+## Round 2 — fixes verified; 1 new medium: BAD_RE false-fail on review-fix "Fix Outcome" skipped-issue prose → fixed round 3 (verdict scan stops at `## Fix Outcome` delimiter, bats added).
+
+## Round 3 (targeted) — delimiter logic verified on 5 dimensions (SCAN_END=1 fail-closed, pipefail safety, line-number mapping, regex vs actual review-fix header across all adapters, 14/14 bats).
+
+## Advisory (inherent, documented): same-actor fake-artifact residual risk — gate blocks optimism-bias hallucination, not conscious evasion; orchestrator-side gate-audit remains defense-in-depth. RESUME_FROM>6 skip is by-design (verdict persisted from prior gated run).
+
+## Verdict
+**0 critical / 0 high / 0 medium / 0 suggestion — APPROVE**
+
+**Vera: N/A** — workflow tooling, no user-facing surface. **Propagation (`prp-install-all`) deferred until v1.6.1 pipeline completes.**

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -436,6 +436,12 @@ Set: `REVIEW_CYCLE = {from state file if --resume, otherwise 1}` (MAX_CYCLES alr
 
 #### 6.1 Run Review
 
+**Before invoking the review command**, capture the invocation timestamp (used by the artifact gate in 6.2.0):
+
+```bash
+REVIEW_STARTED_AT=$(date +%s)
+```
+
 **Choose review command based on `REVIEW_SINGLE_AGENT`:**
 
 | REVIEW_SINGLE_AGENT | Command | Description |
@@ -455,9 +461,32 @@ Pass PR_NUMBER to the chosen command. If `.prp-output/reviews/pr-context-{BRANCH
 **DO NOT**: Read code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke the review command? If not → STOP → invoke it.
 
+#### 6.2.0 Artifact Gate (MANDATORY — mechanical, not from memory)
+
+A review that produced no artifact did not happen. Before evaluating anything,
+verify the artifact ON DISK with the gate script (agent-devops#534 — agents
+reported "review=0-issues" with no artifact three times in one day; the forced
+reviews then found real criticals):
+
+```bash
+# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
+TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+.prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
+```
+
+| Gate exit | Meaning | Action |
+|-----------|---------|--------|
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
+| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp-review-agents` |
+| 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
+
+**DO NOT**: set REVIEW_VERDICT from what the review sub-skill *said* in conversation — only from the gate script's output. A claim without an on-disk artifact is not a review.
+
 #### 6.2 Evaluate Results
 
-Check for issues matching `FIX_SEVERITY` (default: all levels):
+Evaluate from the ARTIFACT FILE (gated in 6.2.0). Check for issues matching `FIX_SEVERITY` (default: all levels):
 
 | Result | Action |
 |--------|--------|
@@ -501,7 +530,9 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
-→ **Return to Step 6.2** to evaluate results.
+**Recapture `REVIEW_STARTED_AT=$(date +%s)` before invoking the re-verify review** (the artifact gate checks freshness per round).
+
+→ **Return to Step 6.2.0** (artifact gate) to evaluate results — re-verify rounds go through the same gate; a re-verify that wrote no fresh artifact did not happen.
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., review-fix ran at least once with all issues skipped — REVIEW_CYCLE is at least 2 after increment — and cannot make further progress), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.

--- a/adapters/antigravity/prp-run-all.md
+++ b/adapters/antigravity/prp-run-all.md
@@ -469,16 +469,26 @@ reported "review=0-issues" with no artifact three times in one day; the forced
 reviews then found real criticals):
 
 ```bash
-# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
-TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+# Round 1 enforces the agents tier (unless --review-single-agent was an
+# explicit caller choice). Re-verify rounds (REVIEW_CYCLE > 1) intentionally
+# use single-agent review, so the gate accepts any tier and picks the NEWEST
+# artifact — the freshness check still rejects stale round-1 leftovers.
+if [ "{REVIEW_CYCLE}" -gt 1 ] || [ "{REVIEW_SINGLE_AGENT}" = "true" ]; then
+  TIER_FLAG=""
+else
+  TIER_FLAG="--require-tier agents"
+fi
 .prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
 ```
 
+**Miss counter (durable — survives compact/resume):** track gate misses in the state file, not memory:
+`.prp/scripts/prp-state.sh set review_miss_count {N}` — increment on exit 1/2, reset to 0 on exit 0.
+
 | Gate exit | Meaning | Action |
 |-----------|---------|--------|
-| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
-| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
-| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | `review_miss_count = 0`. Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | `review_miss_count += 1` (state file). The review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). If `review_miss_count >= 2` → workflow status = "Needs Manual Fixes", NEVER "Complete". Else re-run 6.1 |
+| 2 | artifact stale (predates this run) | Same as exit 1 — counts as a miss, re-run 6.1 |
 | 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp-review-agents` |
 | 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
 

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -438,6 +438,12 @@ Set: `REVIEW_CYCLE = {from state file if --resume, otherwise 1}` (MAX_CYCLES alr
 
 #### 6.1 Run Review
 
+**Before invoking the review command**, capture the invocation timestamp (used by the artifact gate in 6.2.0):
+
+```bash
+REVIEW_STARTED_AT=$(date +%s)
+```
+
 **Choose review command based on `REVIEW_SINGLE_AGENT`:**
 
 | REVIEW_SINGLE_AGENT | Command | Description |
@@ -457,9 +463,32 @@ Pass PR_NUMBER to the chosen command. If `.prp-output/reviews/pr-context-{BRANCH
 **DO NOT**: Read code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke the review command? If not → STOP → invoke it.
 
+#### 6.2.0 Artifact Gate (MANDATORY — mechanical, not from memory)
+
+A review that produced no artifact did not happen. Before evaluating anything,
+verify the artifact ON DISK with the gate script (agent-devops#534 — agents
+reported "review=0-issues" with no artifact three times in one day; the forced
+reviews then found real criticals):
+
+```bash
+# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
+TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+.prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
+```
+
+| Gate exit | Meaning | Action |
+|-----------|---------|--------|
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
+| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp-core:prp-review-agents` |
+| 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
+
+**DO NOT**: set REVIEW_VERDICT from what the review sub-skill *said* in conversation — only from the gate script's output. A claim without an on-disk artifact is not a review.
+
 #### 6.2 Evaluate Results
 
-Check for issues matching `FIX_SEVERITY` (default: all levels):
+Evaluate from the ARTIFACT FILE (gated in 6.2.0). Check for issues matching `FIX_SEVERITY` (default: all levels):
 
 | Result | Action |
 |--------|--------|
@@ -503,7 +532,9 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
-→ **Return to Step 6.2** to evaluate results.
+**Recapture `REVIEW_STARTED_AT=$(date +%s)` before invoking the re-verify review** (the artifact gate checks freshness per round).
+
+→ **Return to Step 6.2.0** (artifact gate) to evaluate results — re-verify rounds go through the same gate; a re-verify that wrote no fresh artifact did not happen.
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., review-fix ran at least once with all issues skipped — REVIEW_CYCLE is at least 2 after increment — and cannot make further progress), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.

--- a/adapters/claude-code/prp-run-all.md
+++ b/adapters/claude-code/prp-run-all.md
@@ -471,16 +471,26 @@ reported "review=0-issues" with no artifact three times in one day; the forced
 reviews then found real criticals):
 
 ```bash
-# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
-TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+# Round 1 enforces the agents tier (unless --review-single-agent was an
+# explicit caller choice). Re-verify rounds (REVIEW_CYCLE > 1) intentionally
+# use single-agent review, so the gate accepts any tier and picks the NEWEST
+# artifact — the freshness check still rejects stale round-1 leftovers.
+if [ "{REVIEW_CYCLE}" -gt 1 ] || [ "{REVIEW_SINGLE_AGENT}" = "true" ]; then
+  TIER_FLAG=""
+else
+  TIER_FLAG="--require-tier agents"
+fi
 .prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
 ```
 
+**Miss counter (durable — survives compact/resume):** track gate misses in the state file, not memory:
+`.prp/scripts/prp-state.sh set review_miss_count {N}` — increment on exit 1/2, reset to 0 on exit 0.
+
 | Gate exit | Meaning | Action |
 |-----------|---------|--------|
-| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
-| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
-| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | `review_miss_count = 0`. Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | `review_miss_count += 1` (state file). The review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). If `review_miss_count >= 2` → workflow status = "Needs Manual Fixes", NEVER "Complete". Else re-run 6.1 |
+| 2 | artifact stale (predates this run) | Same as exit 1 — counts as a miss, re-run 6.1 |
 | 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp-core:prp-review-agents` |
 | 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
 

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -472,16 +472,26 @@ reported "review=0-issues" with no artifact three times in one day; the forced
 reviews then found real criticals):
 
 ```bash
-# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
-TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+# Round 1 enforces the agents tier (unless --review-single-agent was an
+# explicit caller choice). Re-verify rounds (REVIEW_CYCLE > 1) intentionally
+# use single-agent review, so the gate accepts any tier and picks the NEWEST
+# artifact — the freshness check still rejects stale round-1 leftovers.
+if [ "{REVIEW_CYCLE}" -gt 1 ] || [ "{REVIEW_SINGLE_AGENT}" = "true" ]; then
+  TIER_FLAG=""
+else
+  TIER_FLAG="--require-tier agents"
+fi
 .prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
 ```
 
+**Miss counter (durable — survives compact/resume):** track gate misses in the state file, not memory:
+`.prp/scripts/prp-state.sh set review_miss_count {N}` — increment on exit 1/2, reset to 0 on exit 0.
+
 | Gate exit | Meaning | Action |
 |-----------|---------|--------|
-| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
-| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
-| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | `review_miss_count = 0`. Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | `review_miss_count += 1` (state file). The review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). If `review_miss_count >= 2` → workflow status = "Needs Manual Fixes", NEVER "Complete". Else re-run 6.1 |
+| 2 | artifact stale (predates this run) | Same as exit 1 — counts as a miss, re-run 6.1 |
 | 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `$prp-review-agents` |
 | 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
 

--- a/adapters/codex/prp-run-all/SKILL.md
+++ b/adapters/codex/prp-run-all/SKILL.md
@@ -439,6 +439,12 @@ Set: `REVIEW_CYCLE = {from state file if --resume, otherwise 1}` (MAX_CYCLES alr
 
 #### 6.1 Run Review
 
+**Before invoking the review command**, capture the invocation timestamp (used by the artifact gate in 6.2.0):
+
+```bash
+REVIEW_STARTED_AT=$(date +%s)
+```
+
 **Choose review command based on `REVIEW_SINGLE_AGENT`:**
 
 | REVIEW_SINGLE_AGENT | Command | Description |
@@ -458,9 +464,32 @@ Pass PR_NUMBER to the chosen command. If `.prp-output/reviews/pr-context-{BRANCH
 **DO NOT**: Read code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke the review command? If not → STOP → invoke it.
 
+#### 6.2.0 Artifact Gate (MANDATORY — mechanical, not from memory)
+
+A review that produced no artifact did not happen. Before evaluating anything,
+verify the artifact ON DISK with the gate script (agent-devops#534 — agents
+reported "review=0-issues" with no artifact three times in one day; the forced
+reviews then found real criticals):
+
+```bash
+# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
+TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+.prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
+```
+
+| Gate exit | Meaning | Action |
+|-----------|---------|--------|
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
+| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `$prp-review-agents` |
+| 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
+
+**DO NOT**: set REVIEW_VERDICT from what the review sub-skill *said* in conversation — only from the gate script's output. A claim without an on-disk artifact is not a review.
+
 #### 6.2 Evaluate Results
 
-Check for issues matching `FIX_SEVERITY` (default: all levels):
+Evaluate from the ARTIFACT FILE (gated in 6.2.0). Check for issues matching `FIX_SEVERITY` (default: all levels):
 
 | Result | Action |
 |--------|--------|
@@ -504,7 +533,9 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
-→ **Return to Step 6.2** to evaluate results.
+**Recapture `REVIEW_STARTED_AT=$(date +%s)` before invoking the re-verify review** (the artifact gate checks freshness per round).
+
+→ **Return to Step 6.2.0** (artifact gate) to evaluate results — re-verify rounds go through the same gate; a re-verify that wrote no fresh artifact did not happen.
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., review-fix ran at least once with all issues skipped — REVIEW_CYCLE is at least 2 after increment — and cannot make further progress), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -468,16 +468,26 @@ reported "review=0-issues" with no artifact three times in one day; the forced
 reviews then found real criticals):
 
 ```bash
-# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
-TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+# Round 1 enforces the agents tier (unless --review-single-agent was an
+# explicit caller choice). Re-verify rounds (REVIEW_CYCLE > 1) intentionally
+# use single-agent review, so the gate accepts any tier and picks the NEWEST
+# artifact — the freshness check still rejects stale round-1 leftovers.
+if [ "{REVIEW_CYCLE}" -gt 1 ] || [ "{REVIEW_SINGLE_AGENT}" = "true" ]; then
+  TIER_FLAG=""
+else
+  TIER_FLAG="--require-tier agents"
+fi
 .prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
 ```
 
+**Miss counter (durable — survives compact/resume):** track gate misses in the state file, not memory:
+`.prp/scripts/prp-state.sh set review_miss_count {N}` — increment on exit 1/2, reset to 0 on exit 0.
+
 | Gate exit | Meaning | Action |
 |-----------|---------|--------|
-| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
-| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
-| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | `review_miss_count = 0`. Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | `review_miss_count += 1` (state file). The review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). If `review_miss_count >= 2` → workflow status = "Needs Manual Fixes", NEVER "Complete". Else re-run 6.1 |
+| 2 | artifact stale (predates this run) | Same as exit 1 — counts as a miss, re-run 6.1 |
 | 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/review-agents` |
 | 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
 

--- a/adapters/gemini/run-all.toml
+++ b/adapters/gemini/run-all.toml
@@ -435,6 +435,12 @@ Set: `REVIEW_CYCLE = {from state file if --resume, otherwise 1}` (MAX_CYCLES alr
 
 #### 6.1 Run Review
 
+**Before invoking the review command**, capture the invocation timestamp (used by the artifact gate in 6.2.0):
+
+```bash
+REVIEW_STARTED_AT=$(date +%s)
+```
+
 **Choose review command based on `REVIEW_SINGLE_AGENT`:**
 
 | REVIEW_SINGLE_AGENT | Command | Description |
@@ -454,9 +460,32 @@ Pass PR_NUMBER to the chosen command. If `.prp-output/reviews/pr-context-{BRANCH
 **DO NOT**: Read code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke the review command? If not → STOP → invoke it.
 
+#### 6.2.0 Artifact Gate (MANDATORY — mechanical, not from memory)
+
+A review that produced no artifact did not happen. Before evaluating anything,
+verify the artifact ON DISK with the gate script (agent-devops#534 — agents
+reported "review=0-issues" with no artifact three times in one day; the forced
+reviews then found real criticals):
+
+```bash
+# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
+TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+.prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
+```
+
+| Gate exit | Meaning | Action |
+|-----------|---------|--------|
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
+| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/review-agents` |
+| 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
+
+**DO NOT**: set REVIEW_VERDICT from what the review sub-skill *said* in conversation — only from the gate script's output. A claim without an on-disk artifact is not a review.
+
 #### 6.2 Evaluate Results
 
-Check for issues matching `FIX_SEVERITY` (default: all levels):
+Evaluate from the ARTIFACT FILE (gated in 6.2.0). Check for issues matching `FIX_SEVERITY` (default: all levels):
 
 | Result | Action |
 |--------|--------|
@@ -500,7 +529,9 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
-→ **Return to Step 6.2** to evaluate results.
+**Recapture `REVIEW_STARTED_AT=$(date +%s)` before invoking the re-verify review** (the artifact gate checks freshness per round).
+
+→ **Return to Step 6.2.0** (artifact gate) to evaluate results — re-verify rounds go through the same gate; a re-verify that wrote no fresh artifact did not happen.
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., review-fix ran at least once with all issues skipped — REVIEW_CYCLE is at least 2 after increment — and cannot make further progress), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -470,16 +470,26 @@ reported "review=0-issues" with no artifact three times in one day; the forced
 reviews then found real criticals):
 
 ```bash
-# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
-TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+# Round 1 enforces the agents tier (unless --review-single-agent was an
+# explicit caller choice). Re-verify rounds (REVIEW_CYCLE > 1) intentionally
+# use single-agent review, so the gate accepts any tier and picks the NEWEST
+# artifact — the freshness check still rejects stale round-1 leftovers.
+if [ "{REVIEW_CYCLE}" -gt 1 ] || [ "{REVIEW_SINGLE_AGENT}" = "true" ]; then
+  TIER_FLAG=""
+else
+  TIER_FLAG="--require-tier agents"
+fi
 .prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
 ```
 
+**Miss counter (durable — survives compact/resume):** track gate misses in the state file, not memory:
+`.prp/scripts/prp-state.sh set review_miss_count {N}` — increment on exit 1/2, reset to 0 on exit 0.
+
 | Gate exit | Meaning | Action |
 |-----------|---------|--------|
-| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
-| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
-| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | `review_miss_count = 0`. Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | `review_miss_count += 1` (state file). The review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). If `review_miss_count >= 2` → workflow status = "Needs Manual Fixes", NEVER "Complete". Else re-run 6.1 |
+| 2 | artifact stale (predates this run) | Same as exit 1 — counts as a miss, re-run 6.1 |
 | 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp:review-agents` |
 | 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
 

--- a/adapters/opencode/run-all.md
+++ b/adapters/opencode/run-all.md
@@ -437,6 +437,12 @@ Set: `REVIEW_CYCLE = {from state file if --resume, otherwise 1}` (MAX_CYCLES alr
 
 #### 6.1 Run Review
 
+**Before invoking the review command**, capture the invocation timestamp (used by the artifact gate in 6.2.0):
+
+```bash
+REVIEW_STARTED_AT=$(date +%s)
+```
+
 **Choose review command based on `REVIEW_SINGLE_AGENT`:**
 
 | REVIEW_SINGLE_AGENT | Command | Description |
@@ -456,9 +462,32 @@ Pass PR_NUMBER to the chosen command. If `.prp-output/reviews/pr-context-{BRANCH
 **DO NOT**: Read code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke the review command? If not → STOP → invoke it.
 
+#### 6.2.0 Artifact Gate (MANDATORY — mechanical, not from memory)
+
+A review that produced no artifact did not happen. Before evaluating anything,
+verify the artifact ON DISK with the gate script (agent-devops#534 — agents
+reported "review=0-issues" with no artifact three times in one day; the forced
+reviews then found real criticals):
+
+```bash
+# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
+TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+.prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
+```
+
+| Gate exit | Meaning | Action |
+|-----------|---------|--------|
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
+| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp:review-agents` |
+| 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
+
+**DO NOT**: set REVIEW_VERDICT from what the review sub-skill *said* in conversation — only from the gate script's output. A claim without an on-disk artifact is not a review.
+
 #### 6.2 Evaluate Results
 
-Check for issues matching `FIX_SEVERITY` (default: all levels):
+Evaluate from the ARTIFACT FILE (gated in 6.2.0). Check for issues matching `FIX_SEVERITY` (default: all levels):
 
 | Result | Action |
 |--------|--------|
@@ -502,7 +531,9 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
-→ **Return to Step 6.2** to evaluate results.
+**Recapture `REVIEW_STARTED_AT=$(date +%s)` before invoking the re-verify review** (the artifact gate checks freshness per round).
+
+→ **Return to Step 6.2.0** (artifact gate) to evaluate results — re-verify rounds go through the same gate; a re-verify that wrote no fresh artifact did not happen.
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., review-fix ran at least once with all issues skipped — REVIEW_CYCLE is at least 2 after increment — and cannot make further progress), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.

--- a/adapters/thclaws/prp-run-all/SKILL.md
+++ b/adapters/thclaws/prp-run-all/SKILL.md
@@ -439,6 +439,12 @@ Set: `REVIEW_CYCLE = {from state file if --resume, otherwise 1}` (MAX_CYCLES alr
 
 #### 6.1 Run Review
 
+**Before invoking the review command**, capture the invocation timestamp (used by the artifact gate in 6.2.0):
+
+```bash
+REVIEW_STARTED_AT=$(date +%s)
+```
+
 **Choose review command based on `REVIEW_SINGLE_AGENT`:**
 
 | REVIEW_SINGLE_AGENT | Command | Description |
@@ -458,9 +464,32 @@ Pass PR_NUMBER to the chosen command. If `.prp-output/reviews/pr-context-{BRANCH
 **DO NOT**: Read code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke the review command? If not → STOP → invoke it.
 
+#### 6.2.0 Artifact Gate (MANDATORY — mechanical, not from memory)
+
+A review that produced no artifact did not happen. Before evaluating anything,
+verify the artifact ON DISK with the gate script (agent-devops#534 — agents
+reported "review=0-issues" with no artifact three times in one day; the forced
+reviews then found real criticals):
+
+```bash
+# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
+TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+.prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
+```
+
+| Gate exit | Meaning | Action |
+|-----------|---------|--------|
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
+| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp-review-agents` |
+| 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
+
+**DO NOT**: set REVIEW_VERDICT from what the review sub-skill *said* in conversation — only from the gate script's output. A claim without an on-disk artifact is not a review.
+
 #### 6.2 Evaluate Results
 
-Check for issues matching `FIX_SEVERITY` (default: all levels):
+Evaluate from the ARTIFACT FILE (gated in 6.2.0). Check for issues matching `FIX_SEVERITY` (default: all levels):
 
 | Result | Action |
 |--------|--------|
@@ -504,7 +533,9 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
-→ **Return to Step 6.2** to evaluate results.
+**Recapture `REVIEW_STARTED_AT=$(date +%s)` before invoking the re-verify review** (the artifact gate checks freshness per round).
+
+→ **Return to Step 6.2.0** (artifact gate) to evaluate results — re-verify rounds go through the same gate; a re-verify that wrote no fresh artifact did not happen.
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., review-fix ran at least once with all issues skipped — REVIEW_CYCLE is at least 2 after increment — and cannot make further progress), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.

--- a/adapters/thclaws/prp-run-all/SKILL.md
+++ b/adapters/thclaws/prp-run-all/SKILL.md
@@ -472,16 +472,26 @@ reported "review=0-issues" with no artifact three times in one day; the forced
 reviews then found real criticals):
 
 ```bash
-# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
-TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+# Round 1 enforces the agents tier (unless --review-single-agent was an
+# explicit caller choice). Re-verify rounds (REVIEW_CYCLE > 1) intentionally
+# use single-agent review, so the gate accepts any tier and picks the NEWEST
+# artifact — the freshness check still rejects stale round-1 leftovers.
+if [ "{REVIEW_CYCLE}" -gt 1 ] || [ "{REVIEW_SINGLE_AGENT}" = "true" ]; then
+  TIER_FLAG=""
+else
+  TIER_FLAG="--require-tier agents"
+fi
 .prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
 ```
 
+**Miss counter (durable — survives compact/resume):** track gate misses in the state file, not memory:
+`.prp/scripts/prp-state.sh set review_miss_count {N}` — increment on exit 1/2, reset to 0 on exit 0.
+
 | Gate exit | Meaning | Action |
 |-----------|---------|--------|
-| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
-| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
-| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | `review_miss_count = 0`. Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | `review_miss_count += 1` (state file). The review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). If `review_miss_count >= 2` → workflow status = "Needs Manual Fixes", NEVER "Complete". Else re-run 6.1 |
+| 2 | artifact stale (predates this run) | Same as exit 1 — counts as a miss, re-run 6.1 |
 | 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `/prp-review-agents` |
 | 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
 

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -466,16 +466,26 @@ reported "review=0-issues" with no artifact three times in one day; the forced
 reviews then found real criticals):
 
 ```bash
-# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
-TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+# Round 1 enforces the agents tier (unless --review-single-agent was an
+# explicit caller choice). Re-verify rounds (REVIEW_CYCLE > 1) intentionally
+# use single-agent review, so the gate accepts any tier and picks the NEWEST
+# artifact — the freshness check still rejects stale round-1 leftovers.
+if [ "{REVIEW_CYCLE}" -gt 1 ] || [ "{REVIEW_SINGLE_AGENT}" = "true" ]; then
+  TIER_FLAG=""
+else
+  TIER_FLAG="--require-tier agents"
+fi
 .prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
 ```
 
+**Miss counter (durable — survives compact/resume):** track gate misses in the state file, not memory:
+`.prp/scripts/prp-state.sh set review_miss_count {N}` — increment on exit 1/2, reset to 0 on exit 0.
+
 | Gate exit | Meaning | Action |
 |-----------|---------|--------|
-| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
-| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
-| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | `review_miss_count = 0`. Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | `review_miss_count += 1` (state file). The review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). If `review_miss_count >= 2` → workflow status = "Needs Manual Fixes", NEVER "Complete". Else re-run 6.1 |
+| 2 | artifact stale (predates this run) | Same as exit 1 — counts as a miss, re-run 6.1 |
 | 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `{TOOL}:review-agents` |
 | 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
 

--- a/prompts/run-all.md
+++ b/prompts/run-all.md
@@ -433,6 +433,12 @@ Set: `REVIEW_CYCLE = {from state file if --resume, otherwise 1}` (MAX_CYCLES alr
 
 #### 6.1 Run Review
 
+**Before invoking the review command**, capture the invocation timestamp (used by the artifact gate in 6.2.0):
+
+```bash
+REVIEW_STARTED_AT=$(date +%s)
+```
+
 **Choose review command based on `REVIEW_SINGLE_AGENT`:**
 
 | REVIEW_SINGLE_AGENT | Command | Description |
@@ -452,9 +458,32 @@ Pass PR_NUMBER to the chosen command. If `.prp-output/reviews/pr-context-{BRANCH
 **DO NOT**: Read code and review it yourself, skip the skill.
 **CHECKPOINT**: Did you invoke the review command? If not → STOP → invoke it.
 
+#### 6.2.0 Artifact Gate (MANDATORY — mechanical, not from memory)
+
+A review that produced no artifact did not happen. Before evaluating anything,
+verify the artifact ON DISK with the gate script (agent-devops#534 — agents
+reported "review=0-issues" with no artifact three times in one day; the forced
+reviews then found real criticals):
+
+```bash
+# --require-tier agents unless REVIEW_SINGLE_AGENT=true was explicitly set
+TIER_FLAG=$([ "{REVIEW_SINGLE_AGENT}" = "true" ] && echo "" || echo "--require-tier agents")
+.prp/scripts/verify-review-artifact.sh {PR_NUMBER} --since "$REVIEW_STARTED_AT" $TIER_FLAG
+```
+
+| Gate exit | Meaning | Action |
+|-----------|---------|--------|
+| 0 | artifact exists, fresh, tier-correct, verdict 0-issues | Set REVIEW_VERDICT = "0_issues" **from the gate output**, → continue 6.2 |
+| 1 | artifact missing | STOP loop iteration — the review did NOT run. Check pwd (cross-repo cwd resets write artifacts to the wrong repo — see known PRP issue). Re-run 6.1. After 2 consecutive misses → workflow status = "Needs Manual Fixes", NEVER "Complete" |
+| 2 | artifact stale (predates this run) | Same as missing — re-run 6.1 |
+| 3 | wrong tier (single-agent on logic change) | Re-run 6.1 with `{TOOL}:review-agents` |
+| 4 | verdict in FILE is not 0-issues | → Step 6.3 (fix loop) using the artifact's actual findings |
+
+**DO NOT**: set REVIEW_VERDICT from what the review sub-skill *said* in conversation — only from the gate script's output. A claim without an on-disk artifact is not a review.
+
 #### 6.2 Evaluate Results
 
-Check for issues matching `FIX_SEVERITY` (default: all levels):
+Evaluate from the ARTIFACT FILE (gated in 6.2.0). Check for issues matching `FIX_SEVERITY` (default: all levels):
 
 | Result | Action |
 |--------|--------|
@@ -498,7 +527,9 @@ Re-run review to confirm fixes resolved issues and no regressions introduced.
 
 If `--since-last-review` not supported or fails, fall back to full review with `--context` flag. Display: `"WARN: --since-last-review not supported — falling back to full review (higher token cost)."`
 
-→ **Return to Step 6.2** to evaluate results.
+**Recapture `REVIEW_STARTED_AT=$(date +%s)` before invoking the re-verify review** (the artifact gate checks freshness per round).
+
+→ **Return to Step 6.2.0** (artifact gate) to evaluate results — re-verify rounds go through the same gate; a re-verify that wrote no fresh artifact did not happen.
 
 **Escalation guard (NEW 2026-04-17):** before returning to 6.2, if `ALL_SKIPPED = true` AND `REVIEW_CYCLE >= 2` (i.e., review-fix ran at least once with all issues skipped — REVIEW_CYCLE is at least 2 after increment — and cannot make further progress), STOP the loop early:
 - Do NOT loop another round — review-fix has no additional tooling to resolve these.

--- a/scripts/verify-review-artifact.sh
+++ b/scripts/verify-review-artifact.sh
@@ -107,11 +107,25 @@ fi
 GOOD_RE='0[[:space:]]*critical[[:space:]]*/[[:space:]]*0[[:space:]]*(high|important)|READY[[:space:]]+TO[[:space:]]+MERGE'
 BAD_RE='(^|[^0-9.])[1-9][0-9]*[[:space:]]*(critical|high|important|medium|suggestion)s?([^a-z]|$)|NEEDS[[:space:]]+FIXES'
 
-_last_line_no() { # regex -> line number of last match (0 if none)
+# review-fix appends a "## Fix Outcome" section to the original artifact;
+# everything after it is fix bookkeeping (skipped-issue prose like
+# '— 1 critical: needs architectural review'), not the review verdict.
+# Verdict scanning stops at that delimiter.
+SCAN_END=$(grep -inEm1 '^#+[[:space:]]*Fix Outcome' "$ARTIFACT" | cut -d: -f1 || true)
+
+_scan() {
+    if [ -n "$SCAN_END" ]; then
+        head -n $(( SCAN_END - 1 )) "$ARTIFACT"
+    else
+        cat "$ARTIFACT"
+    fi
+}
+
+_last_line_no() { # regex -> line number of last match within scan range (0 if none)
     local n
-    n=$(grep -icE "$1" "$ARTIFACT" 2>/dev/null || true)
+    n=$(_scan | grep -icE "$1" 2>/dev/null || true)
     if [ "${n:-0}" -eq 0 ]; then echo 0; return; fi
-    grep -inE "$1" "$ARTIFACT" | tail -1 | cut -d: -f1
+    _scan | grep -inE "$1" | tail -1 | cut -d: -f1
 }
 
 LAST_GOOD=$(_last_line_no "$GOOD_RE")

--- a/scripts/verify-review-artifact.sh
+++ b/scripts/verify-review-artifact.sh
@@ -49,17 +49,33 @@ done
 
 # --- locate artifact -------------------------------------------------------
 # Multi-agent form first (canonical), then single-agent forms.
-AGENTS_GLOB=("$REVIEWS_DIR"/pr-"$PR_NUMBER"-agents-review*.md)
-SINGLE_GLOB=("$REVIEWS_DIR"/pr-"$PR_NUMBER"-review*.md)
-
+# When agents tier is required, ONLY agents-form artifacts qualify. Otherwise
+# pick the NEWEST artifact across both forms — re-verify rounds write the
+# single-agent form, which must win over a stale round-1 agents artifact.
 ARTIFACT=""
 TIER=""
-if compgen -G "${AGENTS_GLOB[0]}" > /dev/null 2>&1; then
-    ARTIFACT=$(ls -t "$REVIEWS_DIR"/pr-"$PR_NUMBER"-agents-review*.md 2>/dev/null | head -1)
-    TIER="agents"
-elif compgen -G "${SINGLE_GLOB[0]}" > /dev/null 2>&1; then
-    ARTIFACT=$(ls -t "$REVIEWS_DIR"/pr-"$PR_NUMBER"-review*.md 2>/dev/null | head -1)
-    TIER="single"
+if [ "$REQUIRE_TIER" = "agents" ]; then
+    if compgen -G "$REVIEWS_DIR/pr-$PR_NUMBER-agents-review*.md" > /dev/null 2>&1; then
+        ARTIFACT=$(ls -t "$REVIEWS_DIR"/pr-"$PR_NUMBER"-agents-review*.md 2>/dev/null | head -1)
+        TIER="agents"
+    elif compgen -G "$REVIEWS_DIR/pr-$PR_NUMBER-review*.md" > /dev/null 2>&1; then
+        # A single-agent artifact exists but cannot satisfy the agents tier.
+        FOUND_SINGLE=$(ls -t "$REVIEWS_DIR"/pr-"$PR_NUMBER"-review*.md 2>/dev/null | head -1)
+        echo "GATE FAIL (tier): found single-agent artifact '$FOUND_SINGLE' but multi-agent review is required for this change class." >&2
+        echo "  Run the agents-tier review (review-agents); single-agent is allowed for docs-only diffs." >&2
+        exit 3
+    fi
+else
+    if compgen -G "$REVIEWS_DIR/pr-$PR_NUMBER-review*.md" > /dev/null 2>&1 \
+       || compgen -G "$REVIEWS_DIR/pr-$PR_NUMBER-agents-review*.md" > /dev/null 2>&1; then
+        # One of the two globs may be unmatched (passed literally) — ls then
+        # exits non-zero, which pipefail+set-e would turn into a silent death.
+        ARTIFACT=$(ls -t "$REVIEWS_DIR"/pr-"$PR_NUMBER"-review*.md "$REVIEWS_DIR"/pr-"$PR_NUMBER"-agents-review*.md 2>/dev/null | head -1 || true)
+        case "$(basename "$ARTIFACT")" in
+            pr-"$PR_NUMBER"-agents-review*) TIER="agents" ;;
+            *) TIER="single" ;;
+        esac
+    fi
 fi
 
 if [ -z "$ARTIFACT" ] || [ ! -r "$ARTIFACT" ]; then
@@ -70,7 +86,8 @@ fi
 
 # --- freshness -------------------------------------------------------------
 if [ -n "$SINCE_EPOCH" ]; then
-    MTIME=$(stat -c %Y "$ARTIFACT" 2>/dev/null || stat -f %m "$ARTIFACT")
+    MTIME=$(stat -c %Y "$ARTIFACT" 2>/dev/null || stat -f %m "$ARTIFACT" 2>/dev/null \
+        || { echo "GATE FAIL (missing): cannot stat '$ARTIFACT'" >&2; exit 1; })
     if [ "$MTIME" -lt "$SINCE_EPOCH" ]; then
         echo "GATE FAIL (stale): $ARTIFACT mtime=$MTIME < since=$SINCE_EPOCH" >&2
         echo "  Artifact predates this review invocation — likely from an earlier run/branch." >&2
@@ -78,38 +95,37 @@ if [ -n "$SINCE_EPOCH" ]; then
     fi
 fi
 
-# --- tier ------------------------------------------------------------------
-if [ "$REQUIRE_TIER" = "agents" ] && [ "$TIER" != "agents" ]; then
-    echo "GATE FAIL (tier): found single-agent artifact '$ARTIFACT' but multi-agent review is required for this change class." >&2
-    echo "  Run the agents-tier review (review-agents); single-agent is allowed for docs-only diffs." >&2
-    exit 3
-fi
-
 # --- verdict (from FILE content, never from conversation memory) -----------
-# Accept either the canonical zero-count line or an explicit READY TO MERGE
-# verdict that is NOT contradicted by a non-zero count line.
-ZERO_LINE=$(grep -iEm1 '0[[:space:]]*critical[[:space:]]*/[[:space:]]*0[[:space:]]*(high|important)[[:space:]]*/[[:space:]]*0[[:space:]]*medium' "$ARTIFACT" || true)
-READY_LINE=$(grep -iEm1 'READY[[:space:]]+TO[[:space:]]+MERGE' "$ARTIFACT" || true)
-NONZERO_LINE=$(grep -iEm1 '(^|[^0-9])[1-9][0-9]*[[:space:]]*critical|NEEDS[[:space:]]+FIXES' "$ARTIFACT" || true)
+# Position-based: fix-loop artifacts keep round history, so the LAST verdict
+# signal in the file wins. GOOD signals = a zero-counts line or an explicit
+# READY-TO-MERGE/APPROVE verdict. BAD signals = any non-zero severity count
+# (critical/high/important/medium/suggestion) or NEEDS FIXES. The artifact
+# passes only when a GOOD signal exists AND appears AFTER the last BAD signal
+# — an early "0 critical" history line cannot whitewash a later NEEDS FIXES,
+# and remaining suggestions block the gate (zero-issues bar covers ALL
+# severities, matching FIX_SEVERITY's default).
+GOOD_RE='0[[:space:]]*critical[[:space:]]*/[[:space:]]*0[[:space:]]*(high|important)|READY[[:space:]]+TO[[:space:]]+MERGE'
+BAD_RE='(^|[^0-9.])[1-9][0-9]*[[:space:]]*(critical|high|important|medium|suggestion)s?([^a-z]|$)|NEEDS[[:space:]]+FIXES'
 
-# A later READY-TO-MERGE supersedes an earlier NEEDS FIXES in the same file
-# (fix-loop artifacts keep round history). Compare last occurrence positions.
-if [ -n "$NONZERO_LINE" ] && [ -n "$READY_LINE" ]; then
-    LAST_READY=$(grep -inE 'READY[[:space:]]+TO[[:space:]]+MERGE' "$ARTIFACT" | tail -1 | cut -d: -f1)
-    LAST_BAD=$(grep -inE 'NEEDS[[:space:]]+FIXES' "$ARTIFACT" | tail -1 | cut -d: -f1)
-    LAST_BAD=${LAST_BAD:-0}
-    if [ "$LAST_READY" -gt "$LAST_BAD" ]; then
-        NONZERO_LINE=""
-    fi
-fi
+_last_line_no() { # regex -> line number of last match (0 if none)
+    local n
+    n=$(grep -icE "$1" "$ARTIFACT" 2>/dev/null || true)
+    if [ "${n:-0}" -eq 0 ]; then echo 0; return; fi
+    grep -inE "$1" "$ARTIFACT" | tail -1 | cut -d: -f1
+}
 
-if [ -n "$ZERO_LINE" ] || { [ -n "$READY_LINE" ] && [ -z "$NONZERO_LINE" ]; }; then
+LAST_GOOD=$(_last_line_no "$GOOD_RE")
+LAST_BAD=$(_last_line_no "$BAD_RE")
+
+if [ "$LAST_GOOD" -gt 0 ] && [ "$LAST_GOOD" -gt "$LAST_BAD" ]; then
     echo "GATE PASS: $ARTIFACT (tier=$TIER)"
-    echo "VERDICT: ${ZERO_LINE:-$READY_LINE}"
+    echo "VERDICT: $(sed -n "${LAST_GOOD}p" "$ARTIFACT")"
     exit 0
 fi
 
-echo "GATE FAIL (verdict): $ARTIFACT does not show a 0-issues verdict." >&2
-echo "  Last verdict signals: ready='${READY_LINE:-none}' nonzero='${NONZERO_LINE:-none}'" >&2
-echo "  Run the review-fix loop until the artifact itself reads 0 across all severities." >&2
+echo "GATE FAIL (verdict): $ARTIFACT does not end on a 0-issues verdict." >&2
+if [ "$LAST_BAD" -gt 0 ]; then
+    echo "  Last BAD signal (line $LAST_BAD): $(sed -n "${LAST_BAD}p" "$ARTIFACT")" >&2
+fi
+echo "  Run the review-fix loop until the artifact itself reads 0 across ALL severities (suggestions included)." >&2
 exit 4

--- a/scripts/verify-review-artifact.sh
+++ b/scripts/verify-review-artifact.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# PRP Review-Artifact Gate — mechanical post-condition for run-all Step 6.
+#
+# Verifies that a review actually produced a verifiable artifact BEFORE the
+# workflow may report review success. Exists because agents repeatedly claimed
+# "review=0-issues" with no artifact on disk (agent-devops#534: three false
+# claims on 2026-06-11 alone; the forced reviews then found real criticals).
+#
+# Usage:
+#   verify-review-artifact.sh <pr_number> [options]
+#
+# Options:
+#   --reviews-dir <dir>     Artifact directory (default: .prp-output/reviews)
+#   --since <epoch>         Artifact mtime must be >= this UNIX timestamp
+#                           (pass the time the review command was invoked —
+#                           rejects stale artifacts from earlier runs/branches)
+#   --require-tier agents   Artifact filename must be the multi-agent form
+#                           pr-{N}-agents-review*.md (default: any tier)
+#
+# Output: "VERDICT: <line>" on success.
+# Exit codes:
+#   0  pass — artifact exists, fresh, tier-correct, verdict is 0-issues
+#   1  artifact missing (or unreadable)
+#   2  artifact stale (older than --since)
+#   3  wrong tier (single-agent artifact where agents tier required)
+#   4  verdict in artifact is NOT 0-issues / not READY TO MERGE
+#   5  usage error
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+[ -n "$PR_NUMBER" ] || { echo "ERROR: usage: verify-review-artifact.sh <pr_number> [options]" >&2; exit 5; }
+case "$PR_NUMBER" in
+    ''|*[!0-9]*) echo "ERROR: pr_number must be a positive integer, got '$PR_NUMBER'" >&2; exit 5 ;;
+esac
+shift
+
+REVIEWS_DIR=".prp-output/reviews"
+SINCE_EPOCH=""
+REQUIRE_TIER="any"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --reviews-dir) REVIEWS_DIR="${2:?--reviews-dir needs a value}"; shift 2 ;;
+        --since)       SINCE_EPOCH="${2:?--since needs a value}"; shift 2 ;;
+        --require-tier) REQUIRE_TIER="${2:?--require-tier needs a value}"; shift 2 ;;
+        *) echo "ERROR: unknown option '$1'" >&2; exit 5 ;;
+    esac
+done
+
+# --- locate artifact -------------------------------------------------------
+# Multi-agent form first (canonical), then single-agent forms.
+AGENTS_GLOB=("$REVIEWS_DIR"/pr-"$PR_NUMBER"-agents-review*.md)
+SINGLE_GLOB=("$REVIEWS_DIR"/pr-"$PR_NUMBER"-review*.md)
+
+ARTIFACT=""
+TIER=""
+if compgen -G "${AGENTS_GLOB[0]}" > /dev/null 2>&1; then
+    ARTIFACT=$(ls -t "$REVIEWS_DIR"/pr-"$PR_NUMBER"-agents-review*.md 2>/dev/null | head -1)
+    TIER="agents"
+elif compgen -G "${SINGLE_GLOB[0]}" > /dev/null 2>&1; then
+    ARTIFACT=$(ls -t "$REVIEWS_DIR"/pr-"$PR_NUMBER"-review*.md 2>/dev/null | head -1)
+    TIER="single"
+fi
+
+if [ -z "$ARTIFACT" ] || [ ! -r "$ARTIFACT" ]; then
+    echo "GATE FAIL (missing): no review artifact for PR #$PR_NUMBER under $REVIEWS_DIR/" >&2
+    echo "  A review that produced no artifact did not happen. Re-run the review command." >&2
+    exit 1
+fi
+
+# --- freshness -------------------------------------------------------------
+if [ -n "$SINCE_EPOCH" ]; then
+    MTIME=$(stat -c %Y "$ARTIFACT" 2>/dev/null || stat -f %m "$ARTIFACT")
+    if [ "$MTIME" -lt "$SINCE_EPOCH" ]; then
+        echo "GATE FAIL (stale): $ARTIFACT mtime=$MTIME < since=$SINCE_EPOCH" >&2
+        echo "  Artifact predates this review invocation — likely from an earlier run/branch." >&2
+        exit 2
+    fi
+fi
+
+# --- tier ------------------------------------------------------------------
+if [ "$REQUIRE_TIER" = "agents" ] && [ "$TIER" != "agents" ]; then
+    echo "GATE FAIL (tier): found single-agent artifact '$ARTIFACT' but multi-agent review is required for this change class." >&2
+    echo "  Run the agents-tier review (review-agents); single-agent is allowed for docs-only diffs." >&2
+    exit 3
+fi
+
+# --- verdict (from FILE content, never from conversation memory) -----------
+# Accept either the canonical zero-count line or an explicit READY TO MERGE
+# verdict that is NOT contradicted by a non-zero count line.
+ZERO_LINE=$(grep -iEm1 '0[[:space:]]*critical[[:space:]]*/[[:space:]]*0[[:space:]]*(high|important)[[:space:]]*/[[:space:]]*0[[:space:]]*medium' "$ARTIFACT" || true)
+READY_LINE=$(grep -iEm1 'READY[[:space:]]+TO[[:space:]]+MERGE' "$ARTIFACT" || true)
+NONZERO_LINE=$(grep -iEm1 '(^|[^0-9])[1-9][0-9]*[[:space:]]*critical|NEEDS[[:space:]]+FIXES' "$ARTIFACT" || true)
+
+# A later READY-TO-MERGE supersedes an earlier NEEDS FIXES in the same file
+# (fix-loop artifacts keep round history). Compare last occurrence positions.
+if [ -n "$NONZERO_LINE" ] && [ -n "$READY_LINE" ]; then
+    LAST_READY=$(grep -inE 'READY[[:space:]]+TO[[:space:]]+MERGE' "$ARTIFACT" | tail -1 | cut -d: -f1)
+    LAST_BAD=$(grep -inE 'NEEDS[[:space:]]+FIXES' "$ARTIFACT" | tail -1 | cut -d: -f1)
+    LAST_BAD=${LAST_BAD:-0}
+    if [ "$LAST_READY" -gt "$LAST_BAD" ]; then
+        NONZERO_LINE=""
+    fi
+fi
+
+if [ -n "$ZERO_LINE" ] || { [ -n "$READY_LINE" ] && [ -z "$NONZERO_LINE" ]; }; then
+    echo "GATE PASS: $ARTIFACT (tier=$TIER)"
+    echo "VERDICT: ${ZERO_LINE:-$READY_LINE}"
+    exit 0
+fi
+
+echo "GATE FAIL (verdict): $ARTIFACT does not show a 0-issues verdict." >&2
+echo "  Last verdict signals: ready='${READY_LINE:-none}' nonzero='${NONZERO_LINE:-none}'" >&2
+echo "  Run the review-fix loop until the artifact itself reads 0 across all severities." >&2
+exit 4

--- a/tests/run-all/review-artifact-gate.bats
+++ b/tests/run-all/review-artifact-gate.bats
@@ -108,6 +108,18 @@ NEEDS FIXES — 1 critical regression introduced"
     [[ "$output" == *"tier=single"* ]]
 }
 
+@test "fix-outcome appendix with skipped-issue prose does not false-fail a READY verdict" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "**Verdict**: READY TO MERGE — 0 critical / 0 high / 0 medium / 0 suggestion
+
+---
+
+## Fix Outcome
+### Skipped Issues
+- src/auth.ts:45 — 1 critical: requires architectural review"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+}
+
 @test "agents artifact preferred over single when both exist" {
     _write_artifact "$REVIEWS/pr-42-review-claude-code.md" "NEEDS FIXES — 1 critical"
     _write_artifact "$REVIEWS/pr-42-agents-review.md" "0 critical / 0 high / 0 medium / 0 suggestion — APPROVE"

--- a/tests/run-all/review-artifact-gate.bats
+++ b/tests/run-all/review-artifact-gate.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# Tests for scripts/verify-review-artifact.sh (agent-devops#534)
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../../scripts/verify-review-artifact.sh"
+    TMPDIR_GATE=$(mktemp -d)
+    REVIEWS="$TMPDIR_GATE/.prp-output/reviews"
+    mkdir -p "$REVIEWS"
+    cd "$TMPDIR_GATE"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_GATE"
+}
+
+_write_artifact() { # path content
+    printf '%s\n' "$2" > "$1"
+}
+
+@test "missing artifact exits 1" {
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing"* ]]
+}
+
+@test "zero-issues agents artifact passes with tier=agents" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "## Verdict
+0 critical / 0 high / 0 medium / 0 suggestion — APPROVE"
+    run bash "$SCRIPT" 42 --require-tier agents
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GATE PASS"* ]]
+    [[ "$output" == *"tier=agents"* ]]
+}
+
+@test "single-agent artifact fails when agents tier required (exit 3)" {
+    _write_artifact "$REVIEWS/pr-42-review-claude-code.md" "0 critical / 0 high / 0 medium — READY TO MERGE"
+    run bash "$SCRIPT" 42 --require-tier agents
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"tier"* ]]
+}
+
+@test "single-agent artifact passes when any tier allowed" {
+    _write_artifact "$REVIEWS/pr-42-review-claude-code.md" "Verdict: READY TO MERGE — 0 critical / 0 high / 0 medium"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+}
+
+@test "NEEDS FIXES verdict fails (exit 4)" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "## Verdict
+NEEDS FIXES — 2 critical remaining"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 4 ]
+}
+
+@test "fix-loop history: later READY TO MERGE supersedes earlier NEEDS FIXES" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "Round 1: NEEDS FIXES (2 critical)
+Round 2 fixes applied.
+## Final Verdict
+READY TO MERGE — 0 critical / 0 high / 0 medium / 0 suggestion"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+}
+
+@test "stale artifact rejected with --since (exit 2)" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "0 critical / 0 high / 0 medium — APPROVE"
+    touch -d '2020-01-01' "$REVIEWS/pr-42-agents-review.md"
+    run bash "$SCRIPT" 42 --since "$(date +%s)"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "fresh artifact accepted with --since" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "0 critical / 0 high / 0 medium — APPROVE"
+    run bash "$SCRIPT" 42 --since "$(( $(date +%s) - 60 ))"
+    [ "$status" -eq 0 ]
+}
+
+@test "non-numeric pr number exits 5" {
+    run bash "$SCRIPT" "abc"
+    [ "$status" -eq 5 ]
+}
+
+@test "agents artifact preferred over single when both exist" {
+    _write_artifact "$REVIEWS/pr-42-review-claude-code.md" "NEEDS FIXES — 1 critical"
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "0 critical / 0 high / 0 medium / 0 suggestion — APPROVE"
+    run bash "$SCRIPT" 42 --require-tier agents
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pr-42-agents-review.md"* ]]
+}

--- a/tests/run-all/review-artifact-gate.bats
+++ b/tests/run-all/review-artifact-gate.bats
@@ -80,6 +80,34 @@ READY TO MERGE — 0 critical / 0 high / 0 medium / 0 suggestion"
     [ "$status" -eq 5 ]
 }
 
+@test "historical zero-count line cannot whitewash a later NEEDS FIXES (exit 4)" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "## Round 1
+Summary: 0 critical / 0 high / 0 medium — initial pass clean.
+
+## Final Verdict
+NEEDS FIXES — 1 critical regression introduced"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 4 ]
+    [[ "$output" == *"GATE FAIL"* ]]
+}
+
+@test "remaining suggestions block the gate (exit 4)" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "## Verdict
+0 critical / 0 high / 0 medium / 5 suggestion"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 4 ]
+}
+
+@test "re-verify: newer single-agent artifact wins over stale agents artifact when any tier allowed" {
+    _write_artifact "$REVIEWS/pr-42-agents-review.md" "NEEDS FIXES — 2 critical"
+    touch -d '2024-01-01' "$REVIEWS/pr-42-agents-review.md"
+    _write_artifact "$REVIEWS/pr-42-review-claude-code.md" "Re-verify: READY TO MERGE — 0 critical / 0 high / 0 medium / 0 suggestion"
+    run bash "$SCRIPT" 42 --since "$(( $(date +%s) - 60 ))"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pr-42-review-claude-code.md"* ]]
+    [[ "$output" == *"tier=single"* ]]
+}
+
 @test "agents artifact preferred over single when both exist" {
     _write_artifact "$REVIEWS/pr-42-review-claude-code.md" "NEEDS FIXES — 1 critical"
     _write_artifact "$REVIEWS/pr-42-agents-review.md" "0 critical / 0 high / 0 medium / 0 suggestion — APPROVE"


### PR DESCRIPTION
## Summary
- New `scripts/verify-review-artifact.sh` — mechanical post-condition: artifact exists / fresh (`--since` vs `REVIEW_STARTED_AT`) / tier-correct (`--require-tier agents`) / verdict parsed from FILE (READY-TO-MERGE supersedes earlier NEEDS-FIXES in fix-loop history). Exit codes 0-5 mapped to workflow actions.
- run-all.md: new **Step 6.2.0 Artifact Gate** between review invocation and evaluation; `REVIEW_STARTED_AT` captured at 6.1 and recaptured per re-verify round; 6.4 loop returns through the gate; 2 consecutive misses → status 'Needs Manual Fixes', never 'Complete'; explicit cwd-reset hint (cross-repo artifacts landing in wrong repo)
- 10 bats tests, all green

## Why
agent-devops#534 — 3 false 'review=0-issues' claims in one day; forced reviews found 5 criticals total. The workflow trusted the sub-skill's conversational completion; now it trusts only the disk.

## Decision (fix direction 3)
safe-merge tier-check NOT added — tier enforcement stays in run-all + orchestrator gate-audit (safe-merge already gates artifact existence; diff-class context belongs in the workflow). Documented here per AC.

## Post-merge note
**`prp-install-all` propagation DEFERRED** until the v1.6.1 release pipeline (running now) completes — no skill changes under in-flight workflows.

Closes gobikom/agent-devops#534

🤖 Generated with [Claude Code](https://claude.com/claude-code)