### PR TITLE
fix(install): skip helper script copy when .prp symlinks to framework

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -495,15 +495,20 @@ echo -e "${GREEN}  ✅ Created .prp-output/ structure${NC}"
 # Install helper scripts (prp-validate, prp-diff, prp-state)
 echo ""
 echo "🔧 Installing helper scripts..."
-mkdir -p "$PROJECT_DIR/.prp/scripts"
-for script in prp-validate.sh prp-diff.sh prp-state.sh; do
-    if [ -f "$FRAMEWORK_DIR/scripts/$script" ]; then
-        ln -sf "$FRAMEWORK_DIR/scripts/$script" "$PROJECT_DIR/.prp/scripts/$script" 2>/dev/null || \
-        cp "$FRAMEWORK_DIR/scripts/$script" "$PROJECT_DIR/.prp/scripts/$script"
-        [ ! -L "$PROJECT_DIR/.prp/scripts/$script" ] && chmod +x "$PROJECT_DIR/.prp/scripts/$script"
-    fi
-done
-echo -e "${GREEN}  ✅ Installed helper scripts to .prp/scripts/${NC}"
+PRP_LINK_TARGET=$(readlink -f "$PROJECT_DIR/.prp" 2>/dev/null || true)
+if [ "$PRP_LINK_TARGET" = "$(readlink -f "$FRAMEWORK_DIR")" ]; then
+    echo -e "${GREEN}  ✅ .prp is a symlink to framework — helper scripts already accessible${NC}"
+else
+    mkdir -p "$PROJECT_DIR/.prp/scripts"
+    for script in prp-validate.sh prp-diff.sh prp-state.sh; do
+        if [ -f "$FRAMEWORK_DIR/scripts/$script" ]; then
+            ln -sf "$FRAMEWORK_DIR/scripts/$script" "$PROJECT_DIR/.prp/scripts/$script" 2>/dev/null || \
+            cp "$FRAMEWORK_DIR/scripts/$script" "$PROJECT_DIR/.prp/scripts/$script"
+            [ ! -L "$PROJECT_DIR/.prp/scripts/$script" ] && chmod +x "$PROJECT_DIR/.prp/scripts/$script"
+        fi
+    done
+    echo -e "${GREEN}  ✅ Installed helper scripts to .prp/scripts/${NC}"
+fi
 
 # Add gitignore rules to consumer project
 echo ""


### PR DESCRIPTION
## Summary
- When `.prp` is a symlink to the framework directory (standard setup via `prp-install-all`), copying scripts from `framework/scripts/` to `.prp/scripts/` fails with "are the same file"
- Detect this case with `readlink -f` and skip the copy since scripts are already accessible via the symlink
- Fixes `prp-install-all` 47/47 failure after v2.12.0 (#107)

## Test plan
- [x] `readlink -f` correctly detects symlink-to-framework case
- [x] `install.sh` succeeds on agent-psak (symlinked .prp)
- [ ] `prp-install-all` 47/47 success after merge

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>