### PR TITLE
chore: add .no-ci marker (#568)

### DIFF
--- a/.no-ci
+++ b/.no-ci
@@ -1,0 +1,2 @@
+# No CI configured for this repo — safe-merge auto-skips CI check.
+# See agent-devops#568 for rationale.


### PR DESCRIPTION
Declares repo as CI-free for safe-merge. Refs agent-devops#568.