### PR TITLE
fix: skip self-review approve for single-user repos

### DIFF
--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -971,6 +971,13 @@ mkdir -p .prp-output/reviews
 
 ### Post to GitHub
 
+**Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:
+```bash
+PR_AUTHOR=$(gh pr view {NUMBER} --json author --jq '.author.login')
+CURRENT_USER=$(gh api user --jq '.login')
+```
+If `PR_AUTHOR == CURRENT_USER`: skip `gh pr review` (GitHub blocks self-approval) and fall back to `gh pr comment` directly. This is expected in single-user repos where all agents share the same GitHub identity.
+
 | Condition | Action |
 |-----------|--------|
 | READY TO MERGE | `gh pr review {NUMBER} --approve --body-file .prp-output/reviews/pr-{NUMBER}-agents-review.md` |

--- a/prompts/review-agents.md
+++ b/prompts/review-agents.md
@@ -966,6 +966,13 @@ mkdir -p .prp-output/reviews
 
 ### Post to GitHub
 
+**Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:
+```bash
+PR_AUTHOR=$(gh pr view {NUMBER} --json author --jq '.author.login')
+CURRENT_USER=$(gh api user --jq '.login')
+```
+If `PR_AUTHOR == CURRENT_USER`: skip `gh pr review` (GitHub blocks self-approval) and fall back to `gh pr comment` directly. This is expected in single-user repos where all agents share the same GitHub identity.
+
 | Condition | Action |
 |-----------|--------|
 | READY TO MERGE | `gh pr review {NUMBER} --approve --body-file .prp-output/reviews/pr-{NUMBER}-agents-review.md` |


### PR DESCRIPTION
## Summary
- Add self-review detection before `gh pr review --approve`
- If PR author == current user → skip formal review, use `gh pr comment` instead
- Both `prompts/review-agents.md` and `adapters/claude-code/prp-review-agents.md` updated

Fixes gobikom/agent-devops#711

🤖 Generated with [Claude Code](https://claude.com/claude-code)