### PR TITLE
feat: agent-driven docs+translate in Phase 3.5 of implement

### DIFF
--- a/adapters/antigravity/prp-implement.md
+++ b/adapters/antigravity/prp-implement.md
@@ -269,6 +269,50 @@ If you must deviate from the plan:
 
 ---
 
+## Phase 3.5: DOCS — Update Documentation + Translate
+
+**Skip this phase if** the plan's `## Docs Impact` section says "N/A" with justification, OR no `packages/docs/` directory exists in the project.
+
+When the plan has a `## Docs Impact` section listing pages to update:
+
+### 3.5.1 Write/Update EN Documentation
+
+You just implemented the feature — you understand it best. Write the docs now.
+
+1. Read the plan's Docs Impact section for which pages need updating
+2. Read the existing EN page (`packages/docs/src/content/docs/{page}.mdx`)
+3. Add or update the relevant `## ` section with clear, concise documentation
+4. Follow the existing page's style and component usage (Aside, Steps, Badge, etc.)
+
+### 3.5.2 Translate Changed Sections
+
+For each EN section you added or modified:
+
+1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes
+2. For each of the 13 target locales (zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es):
+   - Read the existing locale file (`packages/docs/src/content/docs/{locale}/{page}.mdx`)
+   - Translate ONLY the changed/new section — keep all other sections intact
+   - Preserve exactly: import statements, frontmatter keys, component names, URLs, code blocks, image paths
+   - Translate: headings, paragraphs, list items, text inside components
+   - Write the updated locale file
+3. Update `translate-manifest.json` with new section hashes
+
+### 3.5.3 Validate Docs Build
+
+```bash
+cd packages/docs && pnpm build 2>&1 | tail -5
+```
+
+Must build with zero errors.
+
+### Checklist
+- [ ] EN docs section written/updated for the implemented feature
+- [ ] 13 locale translations updated (changed sections only)
+- [ ] translate-manifest.json updated with section hashes
+- [ ] `pnpm --filter docs build` passes
+
+---
+
 ## Phase 4: VALIDATE - Full Verification
 
 ### 4.1 Static Analysis

--- a/adapters/claude-code/prp-implement.md
+++ b/adapters/claude-code/prp-implement.md
@@ -271,6 +271,50 @@ If you must deviate from the plan:
 
 ---
 
+## Phase 3.5: DOCS — Update Documentation + Translate
+
+**Skip this phase if** the plan's `## Docs Impact` section says "N/A" with justification, OR no `packages/docs/` directory exists in the project.
+
+When the plan has a `## Docs Impact` section listing pages to update:
+
+### 3.5.1 Write/Update EN Documentation
+
+You just implemented the feature — you understand it best. Write the docs now.
+
+1. Read the plan's Docs Impact section for which pages need updating
+2. Read the existing EN page (`packages/docs/src/content/docs/{page}.mdx`)
+3. Add or update the relevant `## ` section with clear, concise documentation
+4. Follow the existing page's style and component usage (Aside, Steps, Badge, etc.)
+
+### 3.5.2 Translate Changed Sections
+
+For each EN section you added or modified:
+
+1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes
+2. For each of the 13 target locales (zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es):
+   - Read the existing locale file (`packages/docs/src/content/docs/{locale}/{page}.mdx`)
+   - Translate ONLY the changed/new section — keep all other sections intact
+   - Preserve exactly: import statements, frontmatter keys, component names, URLs, code blocks, image paths
+   - Translate: headings, paragraphs, list items, text inside components
+   - Write the updated locale file
+3. Update `translate-manifest.json` with new section hashes
+
+### 3.5.3 Validate Docs Build
+
+```bash
+cd packages/docs && pnpm build 2>&1 | tail -5
+```
+
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
+### Checklist
+- [ ] EN docs section written/updated for the implemented feature
+- [ ] 13 locale translations updated (changed sections only)
+- [ ] translate-manifest.json updated with section hashes
+- [ ] `pnpm --filter docs build` passes
+
+---
+
 ## Phase 4: VALIDATE - Full Verification
 
 ### 4.1 Static Analysis

--- a/adapters/claude-code/prp-plan.md
+++ b/adapters/claude-code/prp-plan.md
@@ -505,7 +505,7 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Docs Impact** — list docs pages to update, new pages needed, or "N/A" with per-feature justification. If the plan changes user-facing behavior (features, UI flows, limits, pricing), list which `packages/docs/` pages need updating. Blank = ⚠️ warning at gate audit.
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
 14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
 15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
 16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)

--- a/adapters/codex/prp-implement/SKILL.md
+++ b/adapters/codex/prp-implement/SKILL.md
@@ -272,6 +272,50 @@ If you must deviate from the plan:
 
 ---
 
+## Phase 3.5: DOCS — Update Documentation + Translate
+
+**Skip this phase if** the plan's `## Docs Impact` section says "N/A" with justification, OR no `packages/docs/` directory exists in the project.
+
+When the plan has a `## Docs Impact` section listing pages to update:
+
+### 3.5.1 Write/Update EN Documentation
+
+You just implemented the feature — you understand it best. Write the docs now.
+
+1. Read the plan's Docs Impact section for which pages need updating
+2. Read the existing EN page (`packages/docs/src/content/docs/{page}.mdx`)
+3. Add or update the relevant `## ` section with clear, concise documentation
+4. Follow the existing page's style and component usage (Aside, Steps, Badge, etc.)
+
+### 3.5.2 Translate Changed Sections
+
+For each EN section you added or modified:
+
+1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes
+2. For each of the 13 target locales (zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es):
+   - Read the existing locale file (`packages/docs/src/content/docs/{locale}/{page}.mdx`)
+   - Translate ONLY the changed/new section — keep all other sections intact
+   - Preserve exactly: import statements, frontmatter keys, component names, URLs, code blocks, image paths
+   - Translate: headings, paragraphs, list items, text inside components
+   - Write the updated locale file
+3. Update `translate-manifest.json` with new section hashes
+
+### 3.5.3 Validate Docs Build
+
+```bash
+cd packages/docs && pnpm build 2>&1 | tail -5
+```
+
+Must build with zero errors.
+
+### Checklist
+- [ ] EN docs section written/updated for the implemented feature
+- [ ] 13 locale translations updated (changed sections only)
+- [ ] translate-manifest.json updated with section hashes
+- [ ] `pnpm --filter docs build` passes
+
+---
+
 ## Phase 4: VALIDATE - Full Verification
 
 ### 4.1 Static Analysis

--- a/adapters/thclaws/prp-implement/SKILL.md
+++ b/adapters/thclaws/prp-implement/SKILL.md
@@ -272,6 +272,50 @@ If you must deviate from the plan:
 
 ---
 
+## Phase 3.5: DOCS — Update Documentation + Translate
+
+**Skip this phase if** the plan's `## Docs Impact` section says "N/A" with justification, OR no `packages/docs/` directory exists in the project.
+
+When the plan has a `## Docs Impact` section listing pages to update:
+
+### 3.5.1 Write/Update EN Documentation
+
+You just implemented the feature — you understand it best. Write the docs now.
+
+1. Read the plan's Docs Impact section for which pages need updating
+2. Read the existing EN page (`packages/docs/src/content/docs/{page}.mdx`)
+3. Add or update the relevant `## ` section with clear, concise documentation
+4. Follow the existing page's style and component usage (Aside, Steps, Badge, etc.)
+
+### 3.5.2 Translate Changed Sections
+
+For each EN section you added or modified:
+
+1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes
+2. For each of the 13 target locales (zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es):
+   - Read the existing locale file (`packages/docs/src/content/docs/{locale}/{page}.mdx`)
+   - Translate ONLY the changed/new section — keep all other sections intact
+   - Preserve exactly: import statements, frontmatter keys, component names, URLs, code blocks, image paths
+   - Translate: headings, paragraphs, list items, text inside components
+   - Write the updated locale file
+3. Update `translate-manifest.json` with new section hashes
+
+### 3.5.3 Validate Docs Build
+
+```bash
+cd packages/docs && pnpm build 2>&1 | tail -5
+```
+
+Must build with zero errors.
+
+### Checklist
+- [ ] EN docs section written/updated for the implemented feature
+- [ ] 13 locale translations updated (changed sections only)
+- [ ] translate-manifest.json updated with section hashes
+- [ ] `pnpm --filter docs build` passes
+
+---
+
 ## Phase 4: VALIDATE - Full Verification
 
 ### 4.1 Static Analysis

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -266,6 +266,50 @@ If you must deviate from the plan:
 
 ---
 
+## Phase 3.5: DOCS — Update Documentation + Translate
+
+**Skip this phase if** the plan's `## Docs Impact` section says "N/A" with justification, OR no `packages/docs/` directory exists in the project.
+
+When the plan has a `## Docs Impact` section listing pages to update:
+
+### 3.5.1 Write/Update EN Documentation
+
+You just implemented the feature — you understand it best. Write the docs now.
+
+1. Read the plan's Docs Impact section for which pages need updating
+2. Read the existing EN page (`packages/docs/src/content/docs/{page}.mdx`)
+3. Add or update the relevant `## ` section with clear, concise documentation
+4. Follow the existing page's style and component usage (Aside, Steps, Badge, etc.)
+
+### 3.5.2 Translate Changed Sections
+
+For each EN section you added or modified:
+
+1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes
+2. For each of the 13 target locales (zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es):
+   - Read the existing locale file (`packages/docs/src/content/docs/{locale}/{page}.mdx`)
+   - Translate ONLY the changed/new section — keep all other sections intact
+   - Preserve exactly: import statements, frontmatter keys, component names, URLs, code blocks, image paths
+   - Translate: headings, paragraphs, list items, text inside components
+   - Write the updated locale file
+3. Update `translate-manifest.json` with new section hashes
+
+### 3.5.3 Validate Docs Build
+
+```bash
+cd packages/docs && pnpm build 2>&1 | tail -5
+```
+
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
+### Checklist
+- [ ] EN docs section written/updated for the implemented feature
+- [ ] 13 locale translations updated (changed sections only)
+- [ ] translate-manifest.json updated with section hashes
+- [ ] `pnpm --filter docs build` passes
+
+---
+
 ## Phase 4: VALIDATE - Full Verification
 
 ### 4.1 Static Analysis

--- a/prompts/plan.md
+++ b/prompts/plan.md
@@ -523,7 +523,7 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Docs Impact** — list docs pages to update, new pages needed, or "N/A" with per-feature justification. If the plan changes user-facing behavior (features, UI flows, limits, pricing), list which `packages/docs/` pages need updating. Blank = ⚠️ warning at gate audit.
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
 14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
 15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
 16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)


### PR DESCRIPTION
## Summary
- Add Phase 3.5 (DOCS) to prp-implement across all adapters
- Implementing agent writes EN docs + translates 13 locales in same PR
- Plan template updated: Docs Impact = include in implementation steps
- 7 files: prompts + 5 adapters

Fixes gobikom/agent-devops#715

🤖 Generated with [Claude Code](https://claude.com/claude-code)