### PR TITLE
fix: TH exclusion in Phase 3.5 translation

### DIFF
--- a/adapters/antigravity/prp-implement.md
+++ b/adapters/antigravity/prp-implement.md
@@ -286,6 +286,8 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
+**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+
 For each EN section you added or modified:
 
 1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes

--- a/adapters/claude-code/prp-implement.md
+++ b/adapters/claude-code/prp-implement.md
@@ -288,6 +288,8 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
+**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+
 For each EN section you added or modified:
 
 1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes

--- a/adapters/codex/prp-implement/SKILL.md
+++ b/adapters/codex/prp-implement/SKILL.md
@@ -289,6 +289,8 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
+**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+
 For each EN section you added or modified:
 
 1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes

--- a/adapters/thclaws/prp-implement/SKILL.md
+++ b/adapters/thclaws/prp-implement/SKILL.md
@@ -289,6 +289,8 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
+**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+
 For each EN section you added or modified:
 
 1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -283,6 +283,8 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
+**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+
 For each EN section you added or modified:
 
 1. Read `packages/docs/scripts/translate-manifest.json` for existing section hashes


### PR DESCRIPTION
Add NEVER-translate-TH warning to all implement adapters. Ref: agent-devops#716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)