### PR TITLE
fix: include TH in 14 LLM translation targets

### DIFF
--- a/adapters/antigravity/prp-implement.md
+++ b/adapters/antigravity/prp-implement.md
@@ -286,7 +286,7 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
-**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+**IMPORTANT**: Translate to all 14 non-EN locales: th, zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
 
 For each EN section you added or modified:
 

--- a/adapters/claude-code/prp-implement.md
+++ b/adapters/claude-code/prp-implement.md
@@ -288,7 +288,7 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
-**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+**IMPORTANT**: Translate to all 14 non-EN locales: th, zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
 
 For each EN section you added or modified:
 

--- a/adapters/codex/prp-implement/SKILL.md
+++ b/adapters/codex/prp-implement/SKILL.md
@@ -289,7 +289,7 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
-**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+**IMPORTANT**: Translate to all 14 non-EN locales: th, zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
 
 For each EN section you added or modified:
 

--- a/adapters/thclaws/prp-implement/SKILL.md
+++ b/adapters/thclaws/prp-implement/SKILL.md
@@ -289,7 +289,7 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
-**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+**IMPORTANT**: Translate to all 14 non-EN locales: th, zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
 
 For each EN section you added or modified:
 

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -283,7 +283,7 @@ You just implemented the feature — you understand it best. Write the docs now.
 
 ### 3.5.2 Translate Changed Sections
 
-**IMPORTANT**: NEVER translate to `th` (Thai) — it has human-quality translations. Only translate to these 13 locales: zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
+**IMPORTANT**: Translate to all 14 non-EN locales: th, zh, ja, ko, vi, id, ms, my, hi, ar, ru, fr, de, es.
 
 For each EN section you added or modified:
 


### PR DESCRIPTION
TH is no longer human-only. Updated Phase 3.5 from 13 → 14 locales in all adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)