### PR TITLE
feat(review-agents): emit SHA-bound safe-merge marker (agent-devops#785 gap A Phase 1)

### DIFF
--- a/adapters/antigravity/prp-review-agents.md
+++ b/adapters/antigravity/prp-review-agents.md
@@ -967,6 +967,32 @@ Save aggregated review to `.prp-output/reviews/pr-{NUMBER}-agents-review.md` bef
 mkdir -p .prp-output/reviews
 ```
 
+### Emit safe-merge review marker (agent-devops#785 gap A)
+
+Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
+
+Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+
+**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+```
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+```
+
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
+- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
+- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
+- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+
+```bash
+HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
+printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
+  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+```
+
+Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
+
 ### Post to GitHub
 
 **Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:

--- a/adapters/antigravity/prp-review-agents.md
+++ b/adapters/antigravity/prp-review-agents.md
@@ -999,9 +999,17 @@ CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CR
 IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
 # VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
 AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# Validate VERDICT_TOKEN against the enum (defensive — an aggregation glitch must
+# fail loud, not emit an off-grammar marker).
+case "$VERDICT_TOKEN" in
+  READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
+  *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
+esac
 # head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
 if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [[ -z "$VERDICT_TOKEN" ]]; then
+  : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
     "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \

--- a/adapters/antigravity/prp-review-agents.md
+++ b/adapters/antigravity/prp-review-agents.md
@@ -157,6 +157,12 @@ Extract all context in ONE pass:
 # PR metadata
 gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,state,additions,deletions,changedFiles
 
+# Record the EXACT commit being reviewed, NOW, at diff-gather time. The agents
+# review THIS SHA. The safe-merge marker (see "Emit safe-merge review marker")
+# MUST bind to this value — NOT a value re-queried later — so that any push
+# during review invalidates the marker (marker.head != current head → re-review).
+REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
 if [ -x .prp/scripts/prp-diff.sh ]; then
@@ -971,27 +977,37 @@ mkdir -p .prp-output/reviews
 
 Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
 
-Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+> **Trust model (read this):** the marker is an **integrity/consistency signal for an honest reviewer, NOT an authenticity boundary.** A process that can write this file can write a matching body+marker; the marker does not, by itself, prove a review happened. It does not raise the trust level above the pre-existing local-file-presence gate — it only makes that same signal portable across repos and SHA-bound. `safe-merge` is responsible for re-deriving counts from the body, re-checking the head SHA at merge time, and blocking on any inconsistency. Emit honestly.
 
-**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+Emit for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks the marker against the body.
+
+**Strict grammar** (`safe-merge` matches the whole last line, expects exactly one marker, rejects anything off-grammar → fail-closed):
 ```
-<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-of [a-z0-9-] tokens, no spaces> head=<40-hex-sha> -->
 ```
 
-- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
-- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
-- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
-- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+Field rules:
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
+- `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
+- `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
+- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
 
+Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
-HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
-# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
-printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
-  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+REVIEW_FILE=".prp-output/reviews/pr-{NUMBER}-agents-review.md"
+CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CRIT="${CRIT:-0}"
+IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
+# VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
+AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+else
+  printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    >> "$REVIEW_FILE"
+fi
 ```
-
-Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
 
 ### Post to GitHub
 

--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -159,6 +159,12 @@ Extract all context in ONE pass:
 # PR metadata
 gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,state,additions,deletions,changedFiles
 
+# Record the EXACT commit being reviewed, NOW, at diff-gather time. The agents
+# review THIS SHA. The safe-merge marker (see "Emit safe-merge review marker")
+# MUST bind to this value — NOT a value re-queried later — so that any push
+# during review invalidates the marker (marker.head != current head → re-review).
+REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
 if [ -x .prp/scripts/prp-diff.sh ]; then
@@ -973,27 +979,37 @@ mkdir -p .prp-output/reviews
 
 Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
 
-Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+> **Trust model (read this):** the marker is an **integrity/consistency signal for an honest reviewer, NOT an authenticity boundary.** A process that can write this file can write a matching body+marker; the marker does not, by itself, prove a review happened. It does not raise the trust level above the pre-existing local-file-presence gate — it only makes that same signal portable across repos and SHA-bound. `safe-merge` is responsible for re-deriving counts from the body, re-checking the head SHA at merge time, and blocking on any inconsistency. Emit honestly.
 
-**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+Emit for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks the marker against the body.
+
+**Strict grammar** (`safe-merge` matches the whole last line, expects exactly one marker, rejects anything off-grammar → fail-closed):
 ```
-<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-of [a-z0-9-] tokens, no spaces> head=<40-hex-sha> -->
 ```
 
-- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
-- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
-- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
-- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+Field rules:
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
+- `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
+- `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
+- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
 
+Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
-HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
-# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
-printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
-  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+REVIEW_FILE=".prp-output/reviews/pr-{NUMBER}-agents-review.md"
+CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CRIT="${CRIT:-0}"
+IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
+# VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
+AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+else
+  printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    >> "$REVIEW_FILE"
+fi
 ```
-
-Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
 
 ### Post to GitHub
 

--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -969,6 +969,32 @@ Save aggregated review to `.prp-output/reviews/pr-{NUMBER}-agents-review.md` bef
 mkdir -p .prp-output/reviews
 ```
 
+### Emit safe-merge review marker (agent-devops#785 gap A)
+
+Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
+
+Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+
+**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+```
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+```
+
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
+- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
+- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
+- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+
+```bash
+HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
+printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
+  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+```
+
+Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
+
 ### Post to GitHub
 
 **Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:

--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -1001,9 +1001,17 @@ CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CR
 IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
 # VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
 AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# Validate VERDICT_TOKEN against the enum (defensive — an aggregation glitch must
+# fail loud, not emit an off-grammar marker).
+case "$VERDICT_TOKEN" in
+  READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
+  *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
+esac
 # head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
 if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [[ -z "$VERDICT_TOKEN" ]]; then
+  : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
     "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \

--- a/adapters/codex/prp-review-agents/SKILL.md
+++ b/adapters/codex/prp-review-agents/SKILL.md
@@ -970,6 +970,32 @@ Save aggregated review to `.prp-output/reviews/pr-{NUMBER}-agents-review.md` bef
 mkdir -p .prp-output/reviews
 ```
 
+### Emit safe-merge review marker (agent-devops#785 gap A)
+
+Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
+
+Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+
+**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+```
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+```
+
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
+- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
+- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
+- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+
+```bash
+HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
+printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
+  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+```
+
+Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
+
 ### Post to GitHub
 
 **Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:

--- a/adapters/codex/prp-review-agents/SKILL.md
+++ b/adapters/codex/prp-review-agents/SKILL.md
@@ -1002,9 +1002,17 @@ CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CR
 IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
 # VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
 AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# Validate VERDICT_TOKEN against the enum (defensive — an aggregation glitch must
+# fail loud, not emit an off-grammar marker).
+case "$VERDICT_TOKEN" in
+  READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
+  *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
+esac
 # head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
 if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [[ -z "$VERDICT_TOKEN" ]]; then
+  : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
     "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \

--- a/adapters/codex/prp-review-agents/SKILL.md
+++ b/adapters/codex/prp-review-agents/SKILL.md
@@ -160,6 +160,12 @@ Extract all context in ONE pass:
 # PR metadata
 gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,state,additions,deletions,changedFiles
 
+# Record the EXACT commit being reviewed, NOW, at diff-gather time. The agents
+# review THIS SHA. The safe-merge marker (see "Emit safe-merge review marker")
+# MUST bind to this value — NOT a value re-queried later — so that any push
+# during review invalidates the marker (marker.head != current head → re-review).
+REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
 if [ -x .prp/scripts/prp-diff.sh ]; then
@@ -974,27 +980,37 @@ mkdir -p .prp-output/reviews
 
 Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
 
-Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+> **Trust model (read this):** the marker is an **integrity/consistency signal for an honest reviewer, NOT an authenticity boundary.** A process that can write this file can write a matching body+marker; the marker does not, by itself, prove a review happened. It does not raise the trust level above the pre-existing local-file-presence gate — it only makes that same signal portable across repos and SHA-bound. `safe-merge` is responsible for re-deriving counts from the body, re-checking the head SHA at merge time, and blocking on any inconsistency. Emit honestly.
 
-**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+Emit for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks the marker against the body.
+
+**Strict grammar** (`safe-merge` matches the whole last line, expects exactly one marker, rejects anything off-grammar → fail-closed):
 ```
-<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-of [a-z0-9-] tokens, no spaces> head=<40-hex-sha> -->
 ```
 
-- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
-- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
-- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
-- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+Field rules:
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
+- `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
+- `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
+- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
 
+Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
-HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
-# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
-printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
-  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+REVIEW_FILE=".prp-output/reviews/pr-{NUMBER}-agents-review.md"
+CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CRIT="${CRIT:-0}"
+IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
+# VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
+AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+else
+  printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    >> "$REVIEW_FILE"
+fi
 ```
-
-Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
 
 ### Post to GitHub
 

--- a/adapters/gemini/review-agents.toml
+++ b/adapters/gemini/review-agents.toml
@@ -998,9 +998,17 @@ CRIT=$(grep -oiP '###\\s+Critical Issues\\s+\\(\\K\\d+' "$REVIEW_FILE" | head -1
 IMP=$(grep -oiP '###\\s+Important Issues\\s+\\(\\K\\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
 # VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
 AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# Validate VERDICT_TOKEN against the enum (defensive — an aggregation glitch must
+# fail loud, not emit an off-grammar marker).
+case "$VERDICT_TOKEN" in
+  READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
+  *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
+esac
 # head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
 if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [[ -z "$VERDICT_TOKEN" ]]; then
+  : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\\n' \\
     "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \\

--- a/adapters/gemini/review-agents.toml
+++ b/adapters/gemini/review-agents.toml
@@ -966,7 +966,40 @@ Save aggregated review to `.prp-output/reviews/pr-{NUMBER}-agents-review.md` bef
 mkdir -p .prp-output/reviews
 ```
 
+### Emit safe-merge review marker (agent-devops#785 gap A)
+
+Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
+
+Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+
+**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+```
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+```
+
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
+- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
+- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
+- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+
+```bash
+HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
+printf '\\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\\n' \\
+  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \\
+  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+```
+
+Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
+
 ### Post to GitHub
+
+**Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:
+```bash
+PR_AUTHOR=$(gh pr view {NUMBER} --json author --jq '.author.login')
+CURRENT_USER=$(gh api user --jq '.login')
+```
+If `PR_AUTHOR == CURRENT_USER`: skip `gh pr review` (GitHub blocks self-approval) and fall back to `gh pr comment` directly. This is expected in single-user repos where all agents share the same GitHub identity.
 
 | Condition | Action |
 |-----------|--------|

--- a/adapters/gemini/review-agents.toml
+++ b/adapters/gemini/review-agents.toml
@@ -156,6 +156,12 @@ Extract all context in ONE pass:
 # PR metadata
 gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,state,additions,deletions,changedFiles
 
+# Record the EXACT commit being reviewed, NOW, at diff-gather time. The agents
+# review THIS SHA. The safe-merge marker (see "Emit safe-merge review marker")
+# MUST bind to this value — NOT a value re-queried later — so that any push
+# during review invalidates the marker (marker.head != current head → re-review).
+REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
 if [ -x .prp/scripts/prp-diff.sh ]; then
@@ -970,27 +976,37 @@ mkdir -p .prp-output/reviews
 
 Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
 
-Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+> **Trust model (read this):** the marker is an **integrity/consistency signal for an honest reviewer, NOT an authenticity boundary.** A process that can write this file can write a matching body+marker; the marker does not, by itself, prove a review happened. It does not raise the trust level above the pre-existing local-file-presence gate — it only makes that same signal portable across repos and SHA-bound. `safe-merge` is responsible for re-deriving counts from the body, re-checking the head SHA at merge time, and blocking on any inconsistency. Emit honestly.
 
-**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+Emit for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks the marker against the body.
+
+**Strict grammar** (`safe-merge` matches the whole last line, expects exactly one marker, rejects anything off-grammar → fail-closed):
 ```
-<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-of [a-z0-9-] tokens, no spaces> head=<40-hex-sha> -->
 ```
 
-- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
-- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
-- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
-- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+Field rules:
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
+- `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
+- `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
+- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
 
+Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
-HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
-# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
-printf '\\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\\n' \\
-  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \\
-  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+REVIEW_FILE=".prp-output/reviews/pr-{NUMBER}-agents-review.md"
+CRIT=$(grep -oiP '###\\s+Critical Issues\\s+\\(\\K\\d+' "$REVIEW_FILE" | head -1); CRIT="${CRIT:-0}"
+IMP=$(grep -oiP '###\\s+Important Issues\\s+\\(\\K\\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
+# VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
+AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+else
+  printf '\\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\\n' \\
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \\
+    >> "$REVIEW_FILE"
+fi
 ```
-
-Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
 
 ### Post to GitHub
 

--- a/adapters/opencode/review-agents.md
+++ b/adapters/opencode/review-agents.md
@@ -158,6 +158,12 @@ Extract all context in ONE pass:
 # PR metadata
 gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,state,additions,deletions,changedFiles
 
+# Record the EXACT commit being reviewed, NOW, at diff-gather time. The agents
+# review THIS SHA. The safe-merge marker (see "Emit safe-merge review marker")
+# MUST bind to this value — NOT a value re-queried later — so that any push
+# during review invalidates the marker (marker.head != current head → re-review).
+REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
 if [ -x .prp/scripts/prp-diff.sh ]; then
@@ -972,27 +978,37 @@ mkdir -p .prp-output/reviews
 
 Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
 
-Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+> **Trust model (read this):** the marker is an **integrity/consistency signal for an honest reviewer, NOT an authenticity boundary.** A process that can write this file can write a matching body+marker; the marker does not, by itself, prove a review happened. It does not raise the trust level above the pre-existing local-file-presence gate — it only makes that same signal portable across repos and SHA-bound. `safe-merge` is responsible for re-deriving counts from the body, re-checking the head SHA at merge time, and blocking on any inconsistency. Emit honestly.
 
-**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+Emit for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks the marker against the body.
+
+**Strict grammar** (`safe-merge` matches the whole last line, expects exactly one marker, rejects anything off-grammar → fail-closed):
 ```
-<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-of [a-z0-9-] tokens, no spaces> head=<40-hex-sha> -->
 ```
 
-- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
-- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
-- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
-- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+Field rules:
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
+- `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
+- `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
+- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
 
+Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
-HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
-# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
-printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
-  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+REVIEW_FILE=".prp-output/reviews/pr-{NUMBER}-agents-review.md"
+CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CRIT="${CRIT:-0}"
+IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
+# VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
+AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+else
+  printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    >> "$REVIEW_FILE"
+fi
 ```
-
-Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
 
 ### Post to GitHub
 

--- a/adapters/opencode/review-agents.md
+++ b/adapters/opencode/review-agents.md
@@ -1000,9 +1000,17 @@ CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CR
 IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
 # VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
 AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# Validate VERDICT_TOKEN against the enum (defensive — an aggregation glitch must
+# fail loud, not emit an off-grammar marker).
+case "$VERDICT_TOKEN" in
+  READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
+  *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
+esac
 # head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
 if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [[ -z "$VERDICT_TOKEN" ]]; then
+  : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
     "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \

--- a/adapters/opencode/review-agents.md
+++ b/adapters/opencode/review-agents.md
@@ -968,7 +968,40 @@ Save aggregated review to `.prp-output/reviews/pr-{NUMBER}-agents-review.md` bef
 mkdir -p .prp-output/reviews
 ```
 
+### Emit safe-merge review marker (agent-devops#785 gap A)
+
+Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
+
+Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+
+**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+```
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+```
+
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
+- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
+- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
+- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+
+```bash
+HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
+printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
+  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+```
+
+Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
+
 ### Post to GitHub
+
+**Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:
+```bash
+PR_AUTHOR=$(gh pr view {NUMBER} --json author --jq '.author.login')
+CURRENT_USER=$(gh api user --jq '.login')
+```
+If `PR_AUTHOR == CURRENT_USER`: skip `gh pr review` (GitHub blocks self-approval) and fall back to `gh pr comment` directly. This is expected in single-user repos where all agents share the same GitHub identity.
 
 | Condition | Action |
 |-----------|--------|

--- a/adapters/thclaws/prp-review-agents/SKILL.md
+++ b/adapters/thclaws/prp-review-agents/SKILL.md
@@ -970,6 +970,32 @@ Save aggregated review to `.prp-output/reviews/pr-{NUMBER}-agents-review.md` bef
 mkdir -p .prp-output/reviews
 ```
 
+### Emit safe-merge review marker (agent-devops#785 gap A)
+
+Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
+
+Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+
+**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+```
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+```
+
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
+- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
+- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
+- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+
+```bash
+HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
+printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
+  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+```
+
+Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
+
 ### Post to GitHub
 
 **Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:

--- a/adapters/thclaws/prp-review-agents/SKILL.md
+++ b/adapters/thclaws/prp-review-agents/SKILL.md
@@ -1002,9 +1002,17 @@ CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CR
 IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
 # VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
 AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# Validate VERDICT_TOKEN against the enum (defensive — an aggregation glitch must
+# fail loud, not emit an off-grammar marker).
+case "$VERDICT_TOKEN" in
+  READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
+  *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
+esac
 # head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
 if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [[ -z "$VERDICT_TOKEN" ]]; then
+  : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
     "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \

--- a/adapters/thclaws/prp-review-agents/SKILL.md
+++ b/adapters/thclaws/prp-review-agents/SKILL.md
@@ -160,6 +160,12 @@ Extract all context in ONE pass:
 # PR metadata
 gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,state,additions,deletions,changedFiles
 
+# Record the EXACT commit being reviewed, NOW, at diff-gather time. The agents
+# review THIS SHA. The safe-merge marker (see "Emit safe-merge review marker")
+# MUST bind to this value — NOT a value re-queried later — so that any push
+# during review invalidates the marker (marker.head != current head → re-review).
+REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
 if [ -x .prp/scripts/prp-diff.sh ]; then
@@ -974,27 +980,37 @@ mkdir -p .prp-output/reviews
 
 Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
 
-Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+> **Trust model (read this):** the marker is an **integrity/consistency signal for an honest reviewer, NOT an authenticity boundary.** A process that can write this file can write a matching body+marker; the marker does not, by itself, prove a review happened. It does not raise the trust level above the pre-existing local-file-presence gate — it only makes that same signal portable across repos and SHA-bound. `safe-merge` is responsible for re-deriving counts from the body, re-checking the head SHA at merge time, and blocking on any inconsistency. Emit honestly.
 
-**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+Emit for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks the marker against the body.
+
+**Strict grammar** (`safe-merge` matches the whole last line, expects exactly one marker, rejects anything off-grammar → fail-closed):
 ```
-<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-of [a-z0-9-] tokens, no spaces> head=<40-hex-sha> -->
 ```
 
-- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
-- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
-- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
-- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+Field rules:
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
+- `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
+- `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
+- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
 
+Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
-HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
-# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
-printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
-  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+REVIEW_FILE=".prp-output/reviews/pr-{NUMBER}-agents-review.md"
+CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CRIT="${CRIT:-0}"
+IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
+# VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
+AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+else
+  printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    >> "$REVIEW_FILE"
+fi
 ```
-
-Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
 
 ### Post to GitHub
 

--- a/prompts/review-agents.md
+++ b/prompts/review-agents.md
@@ -996,9 +996,17 @@ CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CR
 IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
 # VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
 AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# Validate VERDICT_TOKEN against the enum (defensive — an aggregation glitch must
+# fail loud, not emit an off-grammar marker).
+case "$VERDICT_TOKEN" in
+  READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
+  *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
+esac
 # head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
 if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [[ -z "$VERDICT_TOKEN" ]]; then
+  : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
     "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \

--- a/prompts/review-agents.md
+++ b/prompts/review-agents.md
@@ -154,6 +154,12 @@ Extract all context in ONE pass:
 # PR metadata
 gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,state,additions,deletions,changedFiles
 
+# Record the EXACT commit being reviewed, NOW, at diff-gather time. The agents
+# review THIS SHA. The safe-merge marker (see "Emit safe-merge review marker")
+# MUST bind to this value — NOT a value re-queried later — so that any push
+# during review invalidates the marker (marker.head != current head → re-review).
+REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
 if [ -x .prp/scripts/prp-diff.sh ]; then
@@ -968,27 +974,37 @@ mkdir -p .prp-output/reviews
 
 Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
 
-Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+> **Trust model (read this):** the marker is an **integrity/consistency signal for an honest reviewer, NOT an authenticity boundary.** A process that can write this file can write a matching body+marker; the marker does not, by itself, prove a review happened. It does not raise the trust level above the pre-existing local-file-presence gate — it only makes that same signal portable across repos and SHA-bound. `safe-merge` is responsible for re-deriving counts from the body, re-checking the head SHA at merge time, and blocking on any inconsistency. Emit honestly.
 
-**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+Emit for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks the marker against the body.
+
+**Strict grammar** (`safe-merge` matches the whole last line, expects exactly one marker, rejects anything off-grammar → fail-closed):
 ```
-<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-of [a-z0-9-] tokens, no spaces> head=<40-hex-sha> -->
 ```
 
-- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
-- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
-- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
-- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+Field rules:
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
+- `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
+- `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
+- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
 
+Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
-HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
-# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
-printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
-  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+REVIEW_FILE=".prp-output/reviews/pr-{NUMBER}-agents-review.md"
+CRIT=$(grep -oiP '###\s+Critical Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); CRIT="${CRIT:-0}"
+IMP=$(grep -oiP '###\s+Important Issues\s+\(\K\d+' "$REVIEW_FILE" | head -1); IMP="${IMP:-0}"
+# VERDICT_TOKEN and AGENTS_CSV from your aggregation. Sanitize agents to the grammar.
+AGENTS_CSV=$(printf '%s' "$AGENTS_CSV" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9,-')
+# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
+if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+else
+  printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    >> "$REVIEW_FILE"
+fi
 ```
-
-Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
 
 ### Post to GitHub
 

--- a/prompts/review-agents.md
+++ b/prompts/review-agents.md
@@ -964,6 +964,32 @@ Save aggregated review to `.prp-output/reviews/pr-{NUMBER}-agents-review.md` bef
 mkdir -p .prp-output/reviews
 ```
 
+### Emit safe-merge review marker (agent-devops#785 gap A)
+
+Append a machine-readable, SHA-bound marker as the **last line** of the review file, **before** posting to GitHub. Because the same file is used both as the local artifact and as the `--body-file` for the GitHub post, the marker lands in **both** places. This lets `safe-merge` satisfy its review gate across worktrees / different-cwd repos and for `-R` cross-repo merges (where it currently skips review entirely).
+
+Emit it for **every** verdict (READY / NEEDS FIXES / CRITICAL) — `safe-merge` must see blocks too, and cross-checks it against the body.
+
+**Strict grammar** (`safe-merge` rejects anything off-grammar, fail-closed):
+```
+<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv-no-spaces> head=<40-hex-sha> -->
+```
+
+- `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`.
+- `critical` / `important` — the SAME integers reported under `### Critical Issues (N found)` / `### Important Issues (N found)`. **`safe-merge` recomputes these from the body headings and BLOCKS on mismatch** — they must be identical. Consistency is also enforced: `READY_TO_MERGE` ⟹ both 0; `CRITICAL_ISSUES` ⟹ critical>0.
+- `agents` — comma-separated, no spaces (e.g. `code-reviewer,security-reviewer,silent-failure-hunter`).
+- `head` — the PR head commit SHA (40 hex). Binds the marker to the reviewed commit so a stale marker can't pass after new commits land.
+
+```bash
+HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# VERDICT_TOKEN, CRIT, IMP, AGENTS_CSV come from your aggregation — CRIT/IMP MUST equal the body headings.
+printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
+  "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$HEAD_SHA" \
+  >> .prp-output/reviews/pr-{NUMBER}-agents-review.md
+```
+
+Do NOT hand-edit the counts to differ from the body — a mismatch makes `safe-merge` block the merge.
+
 ### Post to GitHub
 
 **Self-review detection**: Before posting a formal review, check if the current GitHub user is the PR author:


### PR DESCRIPTION
## What (Phase 1 of agent-devops#785 gap A)

`prp-review-agents` now appends a **SHA-bound, machine-readable marker** as the last line of the review file. Since that same file is the `--body-file` for the GitHub post, the marker lands in **both** the local artifact and the posted PR review/comment:

```
<!-- safe-merge-review: verdict=(READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) critical=<int> important=<int> agents=<csv> head=<40-hex> -->
```

## Why

`safe-merge`'s review gate reads a cwd-relative artifact and **skips entirely for `-R` cross-repo merges** — so worktree/cross-repo reviews can't satisfy it and agents bypass (5 of 17 bypasses/24h in #785, gap A). This marker is the GitHub-side transport that `safe-merge` will read (Phase 2/3) to gate across repos and close the `-R` hole.

## Sequencing (plan R4 — mandatory)

This is **Phase 1 only** (emission). `safe-merge` `-R` enforcement ships **after** this is verified on a throwaway PR — else cross-repo merges hard-block before markers exist. Peer-reviewed by DevLead Codex (APPROVE-WITH-CHANGES, #785).

## Safety notes (for reviewers)

- Marker counts MUST match the body `### Critical Issues (N found)` headings — `safe-merge` (Phase 3) recomputes from the body and blocks on mismatch. This PR just documents that contract.
- Emitted for every verdict (incl. blocks), so `safe-merge` sees CRITICAL/NEEDS_FIXES too.
- Scope: source `prompts/review-agents.md` + regenerated `review-agents` adapters (6 tools) ONLY.

## Separate finding (NOT in this PR)

Regen surfaced pre-existing **adapter drift**: `prp-implement` and `prp-plan` adapters are out of sync with their source prompts (someone edited sources without regenerating). Reverted from this PR to keep scope clean — worth a follow-up `python3 scripts/generate-adapters.py` sweep + commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
