### PR TITLE
feat(plan): always-emit §Gate Compliance scaffold in prp-plan (#799) [2.13.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ Every major version release MUST include a `docs/migration/vX.0-to-vY.0.md` file
 
 ## [Unreleased]
 
+## [2.13.0] — 2026-07-09
+
+### Added
+- **prp-plan §Gate Compliance scaffold** (agent-devops#799): `prompts/plan.md` Phase 6 now
+  emits an always-present `## Gate Compliance` plan section so the pre-implement gate-audit
+  (Layer 3) can mechanically verify operational `/gate` checklist coverage (new_feature +
+  epic_kickoff + post_ship). Tiered content: full item→task mapping for user-facing/endpoint/
+  schema/entity/flag/billing changes; enumerated-`N/A` (blanket N/A rejected, mirrors Docs
+  Impact bar) for internal-only changes. Conditional `/gate audit pre-implement` verify hint
+  for toolchains that ship the gate skill (claude-code/codex); degrades gracefully elsewhere.
+  Regenerated all 6 plan adapters. Companion to soul-orchestra Warden + soul-skills /gate changes.
+
 ## [2.12.0] — 2026-05-27
 
 **Install presets + safe-merge enforcement** — Repos can choose which PRP commands to install. Merge workflow enforces `safe-merge` across all prompts.

--- a/adapters/antigravity/prp-plan.md
+++ b/adapters/antigravity/prp-plan.md
@@ -526,12 +526,17 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Gate Compliance** (ALWAYS emit — agent-devops#799) — a `## Gate Compliance` section that maps the project's `/gate` operational checklists to plan tasks so the pre-implement gate-audit (Layer 3) can verify completeness. Classify the change and scale the content (tiered — never silently omit):
+    - **User-facing / new endpoint / schema / new entity / feature flag / billing change** → map each applicable `new_feature` + `epic_kickoff` + `post_ship` item to an owning plan task/phase: smoke-test L1/L2 for new endpoints, `seed-uat-roles` for new entities, nav entry points for new pages, `ALTER TYPE … ADD VALUE` for new enums, feature-flag verify-all-envs, docs redeploy, post-ship rollback/version-bump/branch-cleanup.
+    - **Genuinely internal-only** (docs/config/refactor with no user-facing or CI-observable change) → `Gate Compliance: N/A — <enumerated reason>`. A blanket "N/A — no new features" is **REJECTED** (mirrors the Docs Impact N/A bar): enumerate what was checked (no `packages/web` pages, no `/api` routes, no schema/entities, no flags/billing) and why none apply.
+    - The always-present, justified classification is what lets the gate-auditor mechanically verify L3. **If this project ships a `/gate` skill (e.g. claude-code/codex), run `/gate audit pre-implement` to verify this section** (other toolchains: skip — this line degrades gracefully).
+15. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+16. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+17. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+18. **Completion Checklist** — all 6 validation levels
+19. **Risks and Mitigations** — likelihood, impact, strategy
+20. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 

--- a/adapters/claude-code/prp-plan.md
+++ b/adapters/claude-code/prp-plan.md
@@ -506,12 +506,16 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
 13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
-14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-17. **Completion Checklist** — all 6 validation levels
-18. **Risks and Mitigations** — likelihood, impact, strategy
-19. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+14. **Gate Compliance** (ALWAYS emit — agent-devops#799) — a `## Gate Compliance` section that maps the project's `/gate` operational checklists to plan tasks so the pre-implement gate-audit (Layer 3) can verify completeness. Classify the change and scale the content (tiered — never silently omit):
+    - **User-facing / new endpoint / schema / new entity / feature flag / billing change** → map each applicable `new_feature` + `epic_kickoff` + `post_ship` item to an owning plan task/phase: smoke-test L1/L2 for new endpoints, `seed-uat-roles` for new entities, nav entry points for new pages, `ALTER TYPE … ADD VALUE` for new enums, feature-flag verify-all-envs, docs redeploy, post-ship rollback/version-bump/branch-cleanup.
+    - **Genuinely internal-only** (docs/config/refactor with no user-facing or CI-observable change) → `Gate Compliance: N/A — <enumerated reason>`. A blanket "N/A — no new features" is **REJECTED** (mirrors the Docs Impact N/A bar): enumerate what was checked (no `packages/web` pages, no `/api` routes, no schema/entities, no flags/billing) and why none apply.
+    - The always-present, justified classification is what lets the gate-auditor mechanically verify L3. **If this project ships a `/gate` skill (e.g. claude-code/codex), run `/gate audit pre-implement` to verify this section** (other toolchains: skip — this line degrades gracefully).
+15. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+16. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+17. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+18. **Completion Checklist** — all 6 validation levels
+19. **Risks and Mitigations** — likelihood, impact, strategy
+20. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 

--- a/adapters/codex/prp-plan/SKILL.md
+++ b/adapters/codex/prp-plan/SKILL.md
@@ -529,12 +529,17 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Gate Compliance** (ALWAYS emit — agent-devops#799) — a `## Gate Compliance` section that maps the project's `/gate` operational checklists to plan tasks so the pre-implement gate-audit (Layer 3) can verify completeness. Classify the change and scale the content (tiered — never silently omit):
+    - **User-facing / new endpoint / schema / new entity / feature flag / billing change** → map each applicable `new_feature` + `epic_kickoff` + `post_ship` item to an owning plan task/phase: smoke-test L1/L2 for new endpoints, `seed-uat-roles` for new entities, nav entry points for new pages, `ALTER TYPE … ADD VALUE` for new enums, feature-flag verify-all-envs, docs redeploy, post-ship rollback/version-bump/branch-cleanup.
+    - **Genuinely internal-only** (docs/config/refactor with no user-facing or CI-observable change) → `Gate Compliance: N/A — <enumerated reason>`. A blanket "N/A — no new features" is **REJECTED** (mirrors the Docs Impact N/A bar): enumerate what was checked (no `packages/web` pages, no `/api` routes, no schema/entities, no flags/billing) and why none apply.
+    - The always-present, justified classification is what lets the gate-auditor mechanically verify L3. **If this project ships a `/gate` skill (e.g. claude-code/codex), run `/gate audit pre-implement` to verify this section** (other toolchains: skip — this line degrades gracefully).
+15. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+16. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+17. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+18. **Completion Checklist** — all 6 validation levels
+19. **Risks and Mitigations** — likelihood, impact, strategy
+20. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 

--- a/adapters/gemini/plan.toml
+++ b/adapters/gemini/plan.toml
@@ -525,12 +525,17 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Gate Compliance** (ALWAYS emit — agent-devops#799) — a `## Gate Compliance` section that maps the project's `/gate` operational checklists to plan tasks so the pre-implement gate-audit (Layer 3) can verify completeness. Classify the change and scale the content (tiered — never silently omit):
+    - **User-facing / new endpoint / schema / new entity / feature flag / billing change** → map each applicable `new_feature` + `epic_kickoff` + `post_ship` item to an owning plan task/phase: smoke-test L1/L2 for new endpoints, `seed-uat-roles` for new entities, nav entry points for new pages, `ALTER TYPE … ADD VALUE` for new enums, feature-flag verify-all-envs, docs redeploy, post-ship rollback/version-bump/branch-cleanup.
+    - **Genuinely internal-only** (docs/config/refactor with no user-facing or CI-observable change) → `Gate Compliance: N/A — <enumerated reason>`. A blanket "N/A — no new features" is **REJECTED** (mirrors the Docs Impact N/A bar): enumerate what was checked (no `packages/web` pages, no `/api` routes, no schema/entities, no flags/billing) and why none apply.
+    - The always-present, justified classification is what lets the gate-auditor mechanically verify L3. **If this project ships a `/gate` skill (e.g. claude-code/codex), run `/gate audit pre-implement` to verify this section** (other toolchains: skip — this line degrades gracefully).
+15. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+16. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+17. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+18. **Completion Checklist** — all 6 validation levels
+19. **Risks and Mitigations** — likelihood, impact, strategy
+20. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 

--- a/adapters/opencode/plan.md
+++ b/adapters/opencode/plan.md
@@ -527,12 +527,17 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Gate Compliance** (ALWAYS emit — agent-devops#799) — a `## Gate Compliance` section that maps the project's `/gate` operational checklists to plan tasks so the pre-implement gate-audit (Layer 3) can verify completeness. Classify the change and scale the content (tiered — never silently omit):
+    - **User-facing / new endpoint / schema / new entity / feature flag / billing change** → map each applicable `new_feature` + `epic_kickoff` + `post_ship` item to an owning plan task/phase: smoke-test L1/L2 for new endpoints, `seed-uat-roles` for new entities, nav entry points for new pages, `ALTER TYPE … ADD VALUE` for new enums, feature-flag verify-all-envs, docs redeploy, post-ship rollback/version-bump/branch-cleanup.
+    - **Genuinely internal-only** (docs/config/refactor with no user-facing or CI-observable change) → `Gate Compliance: N/A — <enumerated reason>`. A blanket "N/A — no new features" is **REJECTED** (mirrors the Docs Impact N/A bar): enumerate what was checked (no `packages/web` pages, no `/api` routes, no schema/entities, no flags/billing) and why none apply.
+    - The always-present, justified classification is what lets the gate-auditor mechanically verify L3. **If this project ships a `/gate` skill (e.g. claude-code/codex), run `/gate audit pre-implement` to verify this section** (other toolchains: skip — this line degrades gracefully).
+15. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+16. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+17. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+18. **Completion Checklist** — all 6 validation levels
+19. **Risks and Mitigations** — likelihood, impact, strategy
+20. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 

--- a/adapters/thclaws/prp-plan/SKILL.md
+++ b/adapters/thclaws/prp-plan/SKILL.md
@@ -529,12 +529,17 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Gate Compliance** (ALWAYS emit — agent-devops#799) — a `## Gate Compliance` section that maps the project's `/gate` operational checklists to plan tasks so the pre-implement gate-audit (Layer 3) can verify completeness. Classify the change and scale the content (tiered — never silently omit):
+    - **User-facing / new endpoint / schema / new entity / feature flag / billing change** → map each applicable `new_feature` + `epic_kickoff` + `post_ship` item to an owning plan task/phase: smoke-test L1/L2 for new endpoints, `seed-uat-roles` for new entities, nav entry points for new pages, `ALTER TYPE … ADD VALUE` for new enums, feature-flag verify-all-envs, docs redeploy, post-ship rollback/version-bump/branch-cleanup.
+    - **Genuinely internal-only** (docs/config/refactor with no user-facing or CI-observable change) → `Gate Compliance: N/A — <enumerated reason>`. A blanket "N/A — no new features" is **REJECTED** (mirrors the Docs Impact N/A bar): enumerate what was checked (no `packages/web` pages, no `/api` routes, no schema/entities, no flags/billing) and why none apply.
+    - The always-present, justified classification is what lets the gate-auditor mechanically verify L3. **If this project ships a `/gate` skill (e.g. claude-code/codex), run `/gate audit pre-implement` to verify this section** (other toolchains: skip — this line degrades gracefully).
+15. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+16. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+17. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+18. **Completion Checklist** — all 6 validation levels
+19. **Risks and Mitigations** — likelihood, impact, strategy
+20. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 

--- a/prompts/plan.md
+++ b/prompts/plan.md
@@ -524,12 +524,16 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
 13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
-14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-17. **Completion Checklist** — all 6 validation levels
-18. **Risks and Mitigations** — likelihood, impact, strategy
-19. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+14. **Gate Compliance** (ALWAYS emit — agent-devops#799) — a `## Gate Compliance` section that maps the project's `/gate` operational checklists to plan tasks so the pre-implement gate-audit (Layer 3) can verify completeness. Classify the change and scale the content (tiered — never silently omit):
+    - **User-facing / new endpoint / schema / new entity / feature flag / billing change** → map each applicable `new_feature` + `epic_kickoff` + `post_ship` item to an owning plan task/phase: smoke-test L1/L2 for new endpoints, `seed-uat-roles` for new entities, nav entry points for new pages, `ALTER TYPE … ADD VALUE` for new enums, feature-flag verify-all-envs, docs redeploy, post-ship rollback/version-bump/branch-cleanup.
+    - **Genuinely internal-only** (docs/config/refactor with no user-facing or CI-observable change) → `Gate Compliance: N/A — <enumerated reason>`. A blanket "N/A — no new features" is **REJECTED** (mirrors the Docs Impact N/A bar): enumerate what was checked (no `packages/web` pages, no `/api` routes, no schema/entities, no flags/billing) and why none apply.
+    - The always-present, justified classification is what lets the gate-auditor mechanically verify L3. **If this project ships a `/gate` skill (e.g. claude-code/codex), run `/gate audit pre-implement` to verify this section** (other toolchains: skip — this line degrades gracefully).
+15. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+16. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+17. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+18. **Completion Checklist** — all 6 validation levels
+19. **Risks and Mitigations** — likelihood, impact, strategy
+20. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 


### PR DESCRIPTION
Part 3/3 of agent-devops#799.

`prompts/plan.md` Phase 6 now requires an always-present `## Gate Compliance` section so the pre-implement gate-audit (Layer 3) can mechanically verify operational /gate checklist coverage.

**Design (loose-coupling — prp scaffolds, Warden/gate verifies; NO hard-coupling to gate rules):**
- Tiered: full new_feature+epic_kickoff+post_ship item→task mapping for user-facing/endpoint/schema/entity/flag/billing; enumerated-N/A for internal-only (blanket N/A rejected, mirrors Docs Impact bar).
- Conditional /gate verify hint in base prompt (claude-code/codex have the skill; others degrade gracefully — no codex overlay invented since only claude-code has overlay support).
- Regenerated all 6 plan adapters (implement/review adapters left untouched — pre-existing drift, out of scope). CHANGELOG 2.13.0.

Companions: soul-orchestra (Warden), soul-skills (/gate SKILL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)