### PR TITLE
feat(plan): commit plan artifact to feature branch for durable git history (#801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Every major version release MUST include a `docs/migration/vX.0-to-vY.0.md` file
 
 ## [Unreleased]
 
+### Added
+- prp-plan now commits the plan artifact to the feature branch (never main) for durable git history (agent-devops#801) — stops the recurring "plan uncommitted in git" Warden flag.
+
 ## [2.12.0] — 2026-05-27
 
 **Install presets + safe-merge enforcement** — Repos can choose which PRP commands to install. Merge workflow enforces `safe-merge` across all prompts.

--- a/adapters/antigravity/prp-implement.md
+++ b/adapters/antigravity/prp-implement.md
@@ -301,6 +301,8 @@ For each EN section you added or modified:
 
 Run the project's docs build command to verify no syntax errors were introduced.
 
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
 ### Checklist
 - [ ] EN docs section written/updated for the implemented feature
 - [ ] 13 locale translations updated (changed sections only)
@@ -623,8 +625,25 @@ Compare the original plan's assessment with what actually happened:
 # Create completed directory if it doesn't exist
 mkdir -p .prp-output/plans/completed
 
-# Move plan to completed folder
-mv "$ARGUMENTS" .prp-output/plans/completed/
+# Move plan to completed folder. If the plan is TRACKED in git (prp-plan committed it, #801),
+# use `git mv` so the archive stays tracked — a plain `mv` would un-track it (.prp-output/** is
+# gitignored for NEW paths, so a later `git add -A` stages the deletion but never re-adds the
+# moved file, silently reverting it to on-disk-only — the exact state #801 fixes). Fall back to
+# plain mv when the plan is not tracked.
+# Collision-safe destination (no -f overwrite — matches the name-collision fallback below):
+DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS")"
+[ -e "$DEST" ] && DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS" .plan.md)-$(date +%Y%m%d-%H%M).plan.md"
+if git ls-files --error-unmatch "$ARGUMENTS" >/dev/null 2>&1; then
+  git mv "$ARGUMENTS" "$DEST"
+  BR=$(git branch --show-current)
+  if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+    git commit -q -m "chore(plan): archive $(basename "$DEST") to completed/" || echo "WARNING: archive commit failed — commit the moved plan manually (#801)"
+  else
+    echo "WARNING: on '${BR:-<detached HEAD>}' — archive move is STAGED but NOT committed (won't commit to main/master/detached). Commit it manually so the plan isn't left uncommitted (#801)."
+  fi
+else
+  mv "$ARGUMENTS" "$DEST"
+fi
 ```
 
 **Verify both destination AND source removal:**

--- a/adapters/antigravity/prp-plan.md
+++ b/adapters/antigravity/prp-plan.md
@@ -526,12 +526,13 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+17. **Completion Checklist** — all 6 validation levels
+18. **Risks and Mitigations** — likelihood, impact, strategy
+19. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 
@@ -548,6 +549,22 @@ test -f ".prp-output/plans/{filename}" || echo "FATAL: Plan file write failed"
 If verification fails, STOP — do not report success.
 
 **If from PRD**: Update PRD status to `in-progress`, link plan file path. After update, verify the PRD file was modified (re-read and confirm status changed). If update fails, WARN: "Could not update PRD status. Manually update the phase status to `in-progress`."
+
+**Commit the plan artifact for durable git history (agent-devops#801):** the plan (and any design/review artifacts under `.prp-output/`) should live in git, not only on disk. After saving, commit the artifact — but ONLY on a real feature branch:
+```bash
+BR=$(git branch --show-current)   # empty on detached HEAD
+if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+  git add -f .prp-output/plans/{filename}
+  if git commit -q -m "docs(plan): {kebab-case-feature-name} plan artifact"; then
+    echo "Plan committed on $BR: $(git rev-parse --short HEAD)"
+  else
+    echo "WARNING: plan commit did not succeed (nothing staged / hook / unset git identity) — commit the artifact manually before it is lost (#801)"
+  fi
+else
+  echo "WARNING: on '${BR:-<detached HEAD>}' — NOT committing plan to main/master or a detached HEAD. Create a feature branch and commit the artifact so it isn't lost (repeatedly flagged by Warden — #801)."
+fi
+```
+The `[ -n "$BR" ]` guard is essential — on a detached HEAD `git branch --show-current` is empty and `"" != "main"` would otherwise pass, orphaning the commit. Never commit plan artifacts directly to main/master. **Report the commit outcome (sha or the WARNING) in the "Report to user" block below** so it is auditable. (Epics: EPIC-ORCHESTRATION kickoff carries a matching 'commit plan/design artifacts to the feature branch' item.)
 
 **Report to user:**
 

--- a/adapters/claude-code/prp-implement.md
+++ b/adapters/claude-code/prp-implement.md
@@ -303,6 +303,8 @@ For each EN section you added or modified:
 
 Run the project's docs build command to verify no syntax errors were introduced.
 
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
 ### Checklist
 - [ ] EN docs section written/updated for the implemented feature
 - [ ] 13 locale translations updated (changed sections only)
@@ -625,8 +627,25 @@ Compare the original plan's assessment with what actually happened:
 # Create completed directory if it doesn't exist
 mkdir -p .prp-output/plans/completed
 
-# Move plan to completed folder
-mv "$ARGUMENTS" .prp-output/plans/completed/
+# Move plan to completed folder. If the plan is TRACKED in git (prp-plan committed it, #801),
+# use `git mv` so the archive stays tracked — a plain `mv` would un-track it (.prp-output/** is
+# gitignored for NEW paths, so a later `git add -A` stages the deletion but never re-adds the
+# moved file, silently reverting it to on-disk-only — the exact state #801 fixes). Fall back to
+# plain mv when the plan is not tracked.
+# Collision-safe destination (no -f overwrite — matches the name-collision fallback below):
+DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS")"
+[ -e "$DEST" ] && DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS" .plan.md)-$(date +%Y%m%d-%H%M).plan.md"
+if git ls-files --error-unmatch "$ARGUMENTS" >/dev/null 2>&1; then
+  git mv "$ARGUMENTS" "$DEST"
+  BR=$(git branch --show-current)
+  if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+    git commit -q -m "chore(plan): archive $(basename "$DEST") to completed/" || echo "WARNING: archive commit failed — commit the moved plan manually (#801)"
+  else
+    echo "WARNING: on '${BR:-<detached HEAD>}' — archive move is STAGED but NOT committed (won't commit to main/master/detached). Commit it manually so the plan isn't left uncommitted (#801)."
+  fi
+else
+  mv "$ARGUMENTS" "$DEST"
+fi
 ```
 
 **Verify both destination AND source removal:**

--- a/adapters/claude-code/prp-plan.md
+++ b/adapters/claude-code/prp-plan.md
@@ -529,6 +529,22 @@ If verification fails, STOP — do not report success.
 
 **If from PRD**: Update PRD status to `in-progress`, link plan file path. After update, verify the PRD file was modified (re-read and confirm status changed). If update fails, WARN: "Could not update PRD status. Manually update the phase status to `in-progress`."
 
+**Commit the plan artifact for durable git history (agent-devops#801):** the plan (and any design/review artifacts under `.prp-output/`) should live in git, not only on disk. After saving, commit the artifact — but ONLY on a real feature branch:
+```bash
+BR=$(git branch --show-current)   # empty on detached HEAD
+if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+  git add -f .prp-output/plans/{filename}
+  if git commit -q -m "docs(plan): {kebab-case-feature-name} plan artifact"; then
+    echo "Plan committed on $BR: $(git rev-parse --short HEAD)"
+  else
+    echo "WARNING: plan commit did not succeed (nothing staged / hook / unset git identity) — commit the artifact manually before it is lost (#801)"
+  fi
+else
+  echo "WARNING: on '${BR:-<detached HEAD>}' — NOT committing plan to main/master or a detached HEAD. Create a feature branch and commit the artifact so it isn't lost (repeatedly flagged by Warden — #801)."
+fi
+```
+The `[ -n "$BR" ]` guard is essential — on a detached HEAD `git branch --show-current` is empty and `"" != "main"` would otherwise pass, orphaning the commit. Never commit plan artifacts directly to main/master. **Report the commit outcome (sha or the WARNING) in the "Report to user" block below** so it is auditable. (Epics: EPIC-ORCHESTRATION kickoff carries a matching 'commit plan/design artifacts to the feature branch' item.)
+
 **Report to user:**
 
 ```markdown

--- a/adapters/codex/prp-implement/SKILL.md
+++ b/adapters/codex/prp-implement/SKILL.md
@@ -304,6 +304,8 @@ For each EN section you added or modified:
 
 Run the project's docs build command to verify no syntax errors were introduced.
 
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
 ### Checklist
 - [ ] EN docs section written/updated for the implemented feature
 - [ ] 13 locale translations updated (changed sections only)
@@ -626,8 +628,25 @@ Compare the original plan's assessment with what actually happened:
 # Create completed directory if it doesn't exist
 mkdir -p .prp-output/plans/completed
 
-# Move plan to completed folder
-mv "$ARGUMENTS" .prp-output/plans/completed/
+# Move plan to completed folder. If the plan is TRACKED in git (prp-plan committed it, #801),
+# use `git mv` so the archive stays tracked — a plain `mv` would un-track it (.prp-output/** is
+# gitignored for NEW paths, so a later `git add -A` stages the deletion but never re-adds the
+# moved file, silently reverting it to on-disk-only — the exact state #801 fixes). Fall back to
+# plain mv when the plan is not tracked.
+# Collision-safe destination (no -f overwrite — matches the name-collision fallback below):
+DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS")"
+[ -e "$DEST" ] && DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS" .plan.md)-$(date +%Y%m%d-%H%M).plan.md"
+if git ls-files --error-unmatch "$ARGUMENTS" >/dev/null 2>&1; then
+  git mv "$ARGUMENTS" "$DEST"
+  BR=$(git branch --show-current)
+  if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+    git commit -q -m "chore(plan): archive $(basename "$DEST") to completed/" || echo "WARNING: archive commit failed — commit the moved plan manually (#801)"
+  else
+    echo "WARNING: on '${BR:-<detached HEAD>}' — archive move is STAGED but NOT committed (won't commit to main/master/detached). Commit it manually so the plan isn't left uncommitted (#801)."
+  fi
+else
+  mv "$ARGUMENTS" "$DEST"
+fi
 ```
 
 **Verify both destination AND source removal:**

--- a/adapters/codex/prp-plan/SKILL.md
+++ b/adapters/codex/prp-plan/SKILL.md
@@ -529,12 +529,13 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+17. **Completion Checklist** — all 6 validation levels
+18. **Risks and Mitigations** — likelihood, impact, strategy
+19. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 
@@ -551,6 +552,22 @@ test -f ".prp-output/plans/{filename}" || echo "FATAL: Plan file write failed"
 If verification fails, STOP — do not report success.
 
 **If from PRD**: Update PRD status to `in-progress`, link plan file path. After update, verify the PRD file was modified (re-read and confirm status changed). If update fails, WARN: "Could not update PRD status. Manually update the phase status to `in-progress`."
+
+**Commit the plan artifact for durable git history (agent-devops#801):** the plan (and any design/review artifacts under `.prp-output/`) should live in git, not only on disk. After saving, commit the artifact — but ONLY on a real feature branch:
+```bash
+BR=$(git branch --show-current)   # empty on detached HEAD
+if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+  git add -f .prp-output/plans/{filename}
+  if git commit -q -m "docs(plan): {kebab-case-feature-name} plan artifact"; then
+    echo "Plan committed on $BR: $(git rev-parse --short HEAD)"
+  else
+    echo "WARNING: plan commit did not succeed (nothing staged / hook / unset git identity) — commit the artifact manually before it is lost (#801)"
+  fi
+else
+  echo "WARNING: on '${BR:-<detached HEAD>}' — NOT committing plan to main/master or a detached HEAD. Create a feature branch and commit the artifact so it isn't lost (repeatedly flagged by Warden — #801)."
+fi
+```
+The `[ -n "$BR" ]` guard is essential — on a detached HEAD `git branch --show-current` is empty and `"" != "main"` would otherwise pass, orphaning the commit. Never commit plan artifacts directly to main/master. **Report the commit outcome (sha or the WARNING) in the "Report to user" block below** so it is auditable. (Epics: EPIC-ORCHESTRATION kickoff carries a matching 'commit plan/design artifacts to the feature branch' item.)
 
 **Report to user:**
 

--- a/adapters/gemini/implement.toml
+++ b/adapters/gemini/implement.toml
@@ -268,6 +268,48 @@ If you must deviate from the plan:
 
 ---
 
+## Phase 3.5: DOCS — Update Documentation + Translate
+
+**Skip this phase if** the plan's `## Docs Impact` section says "N/A" with justification, OR the project has no documentation directory.
+
+When the plan has a `## Docs Impact` section listing pages to update:
+
+### 3.5.1 Write/Update EN Documentation
+
+You just implemented the feature — you understand it best. Write the docs now.
+
+1. Read the plan's Docs Impact section for which pages need updating
+2. Read the existing EN doc page
+3. Add or update the relevant section with clear, concise documentation
+4. Follow the existing page's style and component usage
+
+### 3.5.2 Translate Changed Sections
+
+For each EN section you added or modified:
+
+1. Determine translation targets from the project's locale config (e.g. `locales.ts`, `translate-manifest.json`, or equivalent). Do NOT hardcode locale lists — read from the project's source of truth.
+2. For each target locale:
+   - Read the existing locale file
+   - Translate ONLY the changed/new section — keep all other sections intact
+   - Preserve exactly: import statements, frontmatter keys, component names, URLs, code blocks, image paths
+   - Translate: headings, paragraphs, list items, text inside components
+   - Write the updated locale file
+3. Update the translation manifest with new section hashes
+
+### 3.5.3 Validate Docs Build
+
+Run the project's docs build command to verify no syntax errors were introduced.
+
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
+### Checklist
+- [ ] EN docs section written/updated for the implemented feature
+- [ ] 13 locale translations updated (changed sections only)
+- [ ] translate-manifest.json updated with section hashes
+- [ ] `pnpm --filter docs build` passes
+
+---
+
 ## Phase 4: VALIDATE - Full Verification
 
 ### 4.1 Static Analysis
@@ -582,8 +624,25 @@ Compare the original plan's assessment with what actually happened:
 # Create completed directory if it doesn't exist
 mkdir -p .prp-output/plans/completed
 
-# Move plan to completed folder
-mv "{{args}}" .prp-output/plans/completed/
+# Move plan to completed folder. If the plan is TRACKED in git (prp-plan committed it, #801),
+# use `git mv` so the archive stays tracked — a plain `mv` would un-track it (.prp-output/** is
+# gitignored for NEW paths, so a later `git add -A` stages the deletion but never re-adds the
+# moved file, silently reverting it to on-disk-only — the exact state #801 fixes). Fall back to
+# plain mv when the plan is not tracked.
+# Collision-safe destination (no -f overwrite — matches the name-collision fallback below):
+DEST=".prp-output/plans/completed/$(basename "{{args}}")"
+[ -e "$DEST" ] && DEST=".prp-output/plans/completed/$(basename "{{args}}" .plan.md)-$(date +%Y%m%d-%H%M).plan.md"
+if git ls-files --error-unmatch "{{args}}" >/dev/null 2>&1; then
+  git mv "{{args}}" "$DEST"
+  BR=$(git branch --show-current)
+  if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+    git commit -q -m "chore(plan): archive $(basename "$DEST") to completed/" || echo "WARNING: archive commit failed — commit the moved plan manually (#801)"
+  else
+    echo "WARNING: on '${BR:-<detached HEAD>}' — archive move is STAGED but NOT committed (won't commit to main/master/detached). Commit it manually so the plan isn't left uncommitted (#801)."
+  fi
+else
+  mv "{{args}}" "$DEST"
+fi
 ```
 
 **Verify both destination AND source removal:**

--- a/adapters/gemini/plan.toml
+++ b/adapters/gemini/plan.toml
@@ -525,12 +525,13 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+17. **Completion Checklist** — all 6 validation levels
+18. **Risks and Mitigations** — likelihood, impact, strategy
+19. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 
@@ -547,6 +548,22 @@ test -f ".prp-output/plans/{filename}" || echo "FATAL: Plan file write failed"
 If verification fails, STOP — do not report success.
 
 **If from PRD**: Update PRD status to `in-progress`, link plan file path. After update, verify the PRD file was modified (re-read and confirm status changed). If update fails, WARN: "Could not update PRD status. Manually update the phase status to `in-progress`."
+
+**Commit the plan artifact for durable git history (agent-devops#801):** the plan (and any design/review artifacts under `.prp-output/`) should live in git, not only on disk. After saving, commit the artifact — but ONLY on a real feature branch:
+```bash
+BR=$(git branch --show-current)   # empty on detached HEAD
+if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+  git add -f .prp-output/plans/{filename}
+  if git commit -q -m "docs(plan): {kebab-case-feature-name} plan artifact"; then
+    echo "Plan committed on $BR: $(git rev-parse --short HEAD)"
+  else
+    echo "WARNING: plan commit did not succeed (nothing staged / hook / unset git identity) — commit the artifact manually before it is lost (#801)"
+  fi
+else
+  echo "WARNING: on '${BR:-<detached HEAD>}' — NOT committing plan to main/master or a detached HEAD. Create a feature branch and commit the artifact so it isn't lost (repeatedly flagged by Warden — #801)."
+fi
+```
+The `[ -n "$BR" ]` guard is essential — on a detached HEAD `git branch --show-current` is empty and `"" != "main"` would otherwise pass, orphaning the commit. Never commit plan artifacts directly to main/master. **Report the commit outcome (sha or the WARNING) in the "Report to user" block below** so it is auditable. (Epics: EPIC-ORCHESTRATION kickoff carries a matching 'commit plan/design artifacts to the feature branch' item.)
 
 **Report to user:**
 

--- a/adapters/opencode/implement.md
+++ b/adapters/opencode/implement.md
@@ -270,6 +270,48 @@ If you must deviate from the plan:
 
 ---
 
+## Phase 3.5: DOCS — Update Documentation + Translate
+
+**Skip this phase if** the plan's `## Docs Impact` section says "N/A" with justification, OR the project has no documentation directory.
+
+When the plan has a `## Docs Impact` section listing pages to update:
+
+### 3.5.1 Write/Update EN Documentation
+
+You just implemented the feature — you understand it best. Write the docs now.
+
+1. Read the plan's Docs Impact section for which pages need updating
+2. Read the existing EN doc page
+3. Add or update the relevant section with clear, concise documentation
+4. Follow the existing page's style and component usage
+
+### 3.5.2 Translate Changed Sections
+
+For each EN section you added or modified:
+
+1. Determine translation targets from the project's locale config (e.g. `locales.ts`, `translate-manifest.json`, or equivalent). Do NOT hardcode locale lists — read from the project's source of truth.
+2. For each target locale:
+   - Read the existing locale file
+   - Translate ONLY the changed/new section — keep all other sections intact
+   - Preserve exactly: import statements, frontmatter keys, component names, URLs, code blocks, image paths
+   - Translate: headings, paragraphs, list items, text inside components
+   - Write the updated locale file
+3. Update the translation manifest with new section hashes
+
+### 3.5.3 Validate Docs Build
+
+Run the project's docs build command to verify no syntax errors were introduced.
+
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
+### Checklist
+- [ ] EN docs section written/updated for the implemented feature
+- [ ] 13 locale translations updated (changed sections only)
+- [ ] translate-manifest.json updated with section hashes
+- [ ] `pnpm --filter docs build` passes
+
+---
+
 ## Phase 4: VALIDATE - Full Verification
 
 ### 4.1 Static Analysis
@@ -584,8 +626,25 @@ Compare the original plan's assessment with what actually happened:
 # Create completed directory if it doesn't exist
 mkdir -p .prp-output/plans/completed
 
-# Move plan to completed folder
-mv "$ARGUMENTS" .prp-output/plans/completed/
+# Move plan to completed folder. If the plan is TRACKED in git (prp-plan committed it, #801),
+# use `git mv` so the archive stays tracked — a plain `mv` would un-track it (.prp-output/** is
+# gitignored for NEW paths, so a later `git add -A` stages the deletion but never re-adds the
+# moved file, silently reverting it to on-disk-only — the exact state #801 fixes). Fall back to
+# plain mv when the plan is not tracked.
+# Collision-safe destination (no -f overwrite — matches the name-collision fallback below):
+DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS")"
+[ -e "$DEST" ] && DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS" .plan.md)-$(date +%Y%m%d-%H%M).plan.md"
+if git ls-files --error-unmatch "$ARGUMENTS" >/dev/null 2>&1; then
+  git mv "$ARGUMENTS" "$DEST"
+  BR=$(git branch --show-current)
+  if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+    git commit -q -m "chore(plan): archive $(basename "$DEST") to completed/" || echo "WARNING: archive commit failed — commit the moved plan manually (#801)"
+  else
+    echo "WARNING: on '${BR:-<detached HEAD>}' — archive move is STAGED but NOT committed (won't commit to main/master/detached). Commit it manually so the plan isn't left uncommitted (#801)."
+  fi
+else
+  mv "$ARGUMENTS" "$DEST"
+fi
 ```
 
 **Verify both destination AND source removal:**

--- a/adapters/opencode/plan.md
+++ b/adapters/opencode/plan.md
@@ -527,12 +527,13 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+17. **Completion Checklist** — all 6 validation levels
+18. **Risks and Mitigations** — likelihood, impact, strategy
+19. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 
@@ -549,6 +550,22 @@ test -f ".prp-output/plans/{filename}" || echo "FATAL: Plan file write failed"
 If verification fails, STOP — do not report success.
 
 **If from PRD**: Update PRD status to `in-progress`, link plan file path. After update, verify the PRD file was modified (re-read and confirm status changed). If update fails, WARN: "Could not update PRD status. Manually update the phase status to `in-progress`."
+
+**Commit the plan artifact for durable git history (agent-devops#801):** the plan (and any design/review artifacts under `.prp-output/`) should live in git, not only on disk. After saving, commit the artifact — but ONLY on a real feature branch:
+```bash
+BR=$(git branch --show-current)   # empty on detached HEAD
+if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+  git add -f .prp-output/plans/{filename}
+  if git commit -q -m "docs(plan): {kebab-case-feature-name} plan artifact"; then
+    echo "Plan committed on $BR: $(git rev-parse --short HEAD)"
+  else
+    echo "WARNING: plan commit did not succeed (nothing staged / hook / unset git identity) — commit the artifact manually before it is lost (#801)"
+  fi
+else
+  echo "WARNING: on '${BR:-<detached HEAD>}' — NOT committing plan to main/master or a detached HEAD. Create a feature branch and commit the artifact so it isn't lost (repeatedly flagged by Warden — #801)."
+fi
+```
+The `[ -n "$BR" ]` guard is essential — on a detached HEAD `git branch --show-current` is empty and `"" != "main"` would otherwise pass, orphaning the commit. Never commit plan artifacts directly to main/master. **Report the commit outcome (sha or the WARNING) in the "Report to user" block below** so it is auditable. (Epics: EPIC-ORCHESTRATION kickoff carries a matching 'commit plan/design artifacts to the feature branch' item.)
 
 **Report to user:**
 

--- a/adapters/thclaws/prp-implement/SKILL.md
+++ b/adapters/thclaws/prp-implement/SKILL.md
@@ -304,6 +304,8 @@ For each EN section you added or modified:
 
 Run the project's docs build command to verify no syntax errors were introduced.
 
+Must build with zero errors. If build fails, fix the MDX syntax before proceeding.
+
 ### Checklist
 - [ ] EN docs section written/updated for the implemented feature
 - [ ] 13 locale translations updated (changed sections only)
@@ -626,8 +628,25 @@ Compare the original plan's assessment with what actually happened:
 # Create completed directory if it doesn't exist
 mkdir -p .prp-output/plans/completed
 
-# Move plan to completed folder
-mv "$ARGUMENTS" .prp-output/plans/completed/
+# Move plan to completed folder. If the plan is TRACKED in git (prp-plan committed it, #801),
+# use `git mv` so the archive stays tracked — a plain `mv` would un-track it (.prp-output/** is
+# gitignored for NEW paths, so a later `git add -A` stages the deletion but never re-adds the
+# moved file, silently reverting it to on-disk-only — the exact state #801 fixes). Fall back to
+# plain mv when the plan is not tracked.
+# Collision-safe destination (no -f overwrite — matches the name-collision fallback below):
+DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS")"
+[ -e "$DEST" ] && DEST=".prp-output/plans/completed/$(basename "$ARGUMENTS" .plan.md)-$(date +%Y%m%d-%H%M).plan.md"
+if git ls-files --error-unmatch "$ARGUMENTS" >/dev/null 2>&1; then
+  git mv "$ARGUMENTS" "$DEST"
+  BR=$(git branch --show-current)
+  if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+    git commit -q -m "chore(plan): archive $(basename "$DEST") to completed/" || echo "WARNING: archive commit failed — commit the moved plan manually (#801)"
+  else
+    echo "WARNING: on '${BR:-<detached HEAD>}' — archive move is STAGED but NOT committed (won't commit to main/master/detached). Commit it manually so the plan isn't left uncommitted (#801)."
+  fi
+else
+  mv "$ARGUMENTS" "$DEST"
+fi
 ```
 
 **Verify both destination AND source removal:**

--- a/adapters/thclaws/prp-plan/SKILL.md
+++ b/adapters/thclaws/prp-plan/SKILL.md
@@ -529,12 +529,13 @@ The plan file MUST include lifecycle frontmatter (`status: pending`, `runner`, `
     - **GOTCHA**: Known pitfalls to avoid
     - **VALIDATE**: Exact command to verify (pre-filled, no placeholders)
 12. **Testing Strategy** — unit tests table + integration tests (conditional) + test data + performance benchmarks (conditional) + edge cases checklist
-13. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
-14. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
-15. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
-16. **Completion Checklist** — all 6 validation levels
-17. **Risks and Mitigations** — likelihood, impact, strategy
-18. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
+13. **Docs Impact** — list docs pages to update/create, or "N/A" with per-feature justification. If the plan changes user-facing behavior, list which `packages/docs/` pages need updating and include docs + translation as implementation steps (the implementing agent writes EN docs + translates to 13 locales in the same PR). Blank = ⚠️ warning at gate audit.
+14. **Validation Commands** — 6 levels (Static Analysis, Unit Tests, Full Suite, Database, Browser, Manual), **pre-filled with actual commands**
+15. **Confidence Score** — 5 dimensions × 2pts = 10 formula: Patterns + Gotchas + Integration + Validation + Testing
+16. **Acceptance Criteria** — definition of done (including unit tests cover >= 90% of new code)
+17. **Completion Checklist** — all 6 validation levels
+18. **Risks and Mitigations** — likelihood, impact, strategy
+19. **Technical Design** (conditional, HIGH or API/DB) — API contracts, DB schema, sequence diagrams, NFRs, migration & rollback
 
 **IMPORTANT**: The saved plan file MUST NOT contain any unfilled `{...}` placeholders in Validation Commands section. Pre-fill with actual detected commands.
 
@@ -551,6 +552,22 @@ test -f ".prp-output/plans/{filename}" || echo "FATAL: Plan file write failed"
 If verification fails, STOP — do not report success.
 
 **If from PRD**: Update PRD status to `in-progress`, link plan file path. After update, verify the PRD file was modified (re-read and confirm status changed). If update fails, WARN: "Could not update PRD status. Manually update the phase status to `in-progress`."
+
+**Commit the plan artifact for durable git history (agent-devops#801):** the plan (and any design/review artifacts under `.prp-output/`) should live in git, not only on disk. After saving, commit the artifact — but ONLY on a real feature branch:
+```bash
+BR=$(git branch --show-current)   # empty on detached HEAD
+if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+  git add -f .prp-output/plans/{filename}
+  if git commit -q -m "docs(plan): {kebab-case-feature-name} plan artifact"; then
+    echo "Plan committed on $BR: $(git rev-parse --short HEAD)"
+  else
+    echo "WARNING: plan commit did not succeed (nothing staged / hook / unset git identity) — commit the artifact manually before it is lost (#801)"
+  fi
+else
+  echo "WARNING: on '${BR:-<detached HEAD>}' — NOT committing plan to main/master or a detached HEAD. Create a feature branch and commit the artifact so it isn't lost (repeatedly flagged by Warden — #801)."
+fi
+```
+The `[ -n "$BR" ]` guard is essential — on a detached HEAD `git branch --show-current` is empty and `"" != "main"` would otherwise pass, orphaning the commit. Never commit plan artifacts directly to main/master. **Report the commit outcome (sha or the WARNING) in the "Report to user" block below** so it is auditable. (Epics: EPIC-ORCHESTRATION kickoff carries a matching 'commit plan/design artifacts to the feature branch' item.)
 
 **Report to user:**
 

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -622,8 +622,25 @@ Compare the original plan's assessment with what actually happened:
 # Create completed directory if it doesn't exist
 mkdir -p .prp-output/plans/completed
 
-# Move plan to completed folder
-mv "{ARGS}" .prp-output/plans/completed/
+# Move plan to completed folder. If the plan is TRACKED in git (prp-plan committed it, #801),
+# use `git mv` so the archive stays tracked — a plain `mv` would un-track it (.prp-output/** is
+# gitignored for NEW paths, so a later `git add -A` stages the deletion but never re-adds the
+# moved file, silently reverting it to on-disk-only — the exact state #801 fixes). Fall back to
+# plain mv when the plan is not tracked.
+# Collision-safe destination (no -f overwrite — matches the name-collision fallback below):
+DEST=".prp-output/plans/completed/$(basename "{ARGS}")"
+[ -e "$DEST" ] && DEST=".prp-output/plans/completed/$(basename "{ARGS}" .plan.md)-$(date +%Y%m%d-%H%M).plan.md"
+if git ls-files --error-unmatch "{ARGS}" >/dev/null 2>&1; then
+  git mv "{ARGS}" "$DEST"
+  BR=$(git branch --show-current)
+  if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+    git commit -q -m "chore(plan): archive $(basename "$DEST") to completed/" || echo "WARNING: archive commit failed — commit the moved plan manually (#801)"
+  else
+    echo "WARNING: on '${BR:-<detached HEAD>}' — archive move is STAGED but NOT committed (won't commit to main/master/detached). Commit it manually so the plan isn't left uncommitted (#801)."
+  fi
+else
+  mv "{ARGS}" "$DEST"
+fi
 ```
 
 **Verify both destination AND source removal:**

--- a/prompts/plan.md
+++ b/prompts/plan.md
@@ -547,6 +547,22 @@ If verification fails, STOP — do not report success.
 
 **If from PRD**: Update PRD status to `in-progress`, link plan file path. After update, verify the PRD file was modified (re-read and confirm status changed). If update fails, WARN: "Could not update PRD status. Manually update the phase status to `in-progress`."
 
+**Commit the plan artifact for durable git history (agent-devops#801):** the plan (and any design/review artifacts under `.prp-output/`) should live in git, not only on disk. After saving, commit the artifact — but ONLY on a real feature branch:
+```bash
+BR=$(git branch --show-current)   # empty on detached HEAD
+if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$BR" != "master" ]; then
+  git add -f .prp-output/plans/{filename}
+  if git commit -q -m "docs(plan): {kebab-case-feature-name} plan artifact"; then
+    echo "Plan committed on $BR: $(git rev-parse --short HEAD)"
+  else
+    echo "WARNING: plan commit did not succeed (nothing staged / hook / unset git identity) — commit the artifact manually before it is lost (#801)"
+  fi
+else
+  echo "WARNING: on '${BR:-<detached HEAD>}' — NOT committing plan to main/master or a detached HEAD. Create a feature branch and commit the artifact so it isn't lost (repeatedly flagged by Warden — #801)."
+fi
+```
+The `[ -n "$BR" ]` guard is essential — on a detached HEAD `git branch --show-current` is empty and `"" != "main"` would otherwise pass, orphaning the commit. Never commit plan artifacts directly to main/master. **Report the commit outcome (sha or the WARNING) in the "Report to user" block below** so it is auditable. (Epics: EPIC-ORCHESTRATION kickoff carries a matching 'commit plan/design artifacts to the feature branch' item.)
+
 **Report to user:**
 
 ```markdown


### PR DESCRIPTION
prp-plan wrote artifacts to `.prp-output/` but never committed them — Warden flagged 'plan/design uncommitted in git' 3× (v1.12 ×2, v1.13).

`prompts/plan.md` Output now: after saving, if on a feature branch (not main), `git add -f` + commit the plan artifact; if on main, WARN to branch first. Never commits to main. Regenerated 6 plan adapters + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)