### PR TITLE
fix(review-agents): commit artifacts before marker; docs-only head re-bind (#121)

### DIFF
--- a/.prp-output/reviews/pr-122-agents-review.md
+++ b/.prp-output/reviews/pr-122-agents-review.md
@@ -1,0 +1,46 @@
+---
+pr: 122
+title: "fix(review-agents): commit artifacts before marker; docs-only head re-bind (#121)"
+author: "gobikom"
+reviewed: 2026-07-10T16:05:00+07:00
+verdict: READY TO MERGE
+agents: [code-reviewer, security-reviewer, silent-failure-hunter]
+rounds: 2
+---
+
+## PR Review Summary (Multi-Agent — converged after fix loop)
+
+Round 1 (3 core agents, head b77c435): 1 critical / 0 important / 2 medium → NEEDS FIXES.
+Fix round (37e05486e): all 3 fixed, 0 skipped. Round 2 re-verify: behavioral test matrix green.
+
+### Critical Issues (0 found)
+
+None remaining. Resolved: the docs-only guard failed OPEN when REVIEWED_HEAD_SHA was empty (`git diff ""..HEAD` silently prints nothing) or unresolvable (exit 128 swallowed by the pipeline) — both empirically confirmed by two independent agents. Now both SHAs are validated as 40-hex before any diff (and at Phase-1.3 capture), and git diff's output + exit code are captured separately: any git error = FATAL, no re-bind.
+
+### Important Issues (0 found)
+
+None. (Security Medium resolved: rename detection let `git mv src/x .prp-output/y` show only the destination, silently dropping a reviewed file from the merged tree — `--no-renames` now lists both paths so the deletion FATALs. Docs Medium resolved: emit-block regex documented as format backstop only.)
+
+### Re-verify evidence (round 2, behavioral matrix on a sandbox repo)
+| Case | Result |
+|------|--------|
+| same head | binds reviewed SHA |
+| docs-only advance | REBIND ✓ |
+| empty REVIEWED_HEAD_SHA | FATAL (was the critical fail-open) |
+| unresolvable SHA | FATAL-DIFF(128) (was silent) |
+| rename into .prp-output/ | FATAL-DRIFT (was the security bypass) |
+| real code drift | FATAL-DRIFT |
+
+### Validation Results
+| Check | Status | Details |
+|-------|--------|---------|
+| generate-adapters | PASS | 6 generated, 0 errors, idempotent re-run |
+| bash -n (guard snippet) | PASS | clean |
+| parity.bats | 91 ok / 8 not ok | the 8 are PRE-EXISTING on main (stale 19/28 count expectations vs current 22/32; identical set verified on origin/main) — follow-up candidate, untouched here |
+
+### Strengths
+- Ordering fix verified consistent file-wide: no section instructs a commit after marker emission; field rules ↔ guard ↔ emit block all reference MARKER_HEAD with no stale REVIEWED_HEAD_SHA in the printf path.
+- Security posture delta vs baseline: none remaining — .prp-output/ carries no executable effect for safe-merge; marker↔body count coupling unchanged; injection direction was always caught, deletion direction now caught via --no-renames.
+
+### Verdict
+READY TO MERGE

--- a/adapters/antigravity/prp-review-agents.md
+++ b/adapters/antigravity/prp-review-agents.md
@@ -162,6 +162,10 @@ gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,stat
 # MUST bind to this value — NOT a value re-queried later — so that any push
 # during review invalidates the marker (marker.head != current head → re-review).
 REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# Validate immediately — an empty/garbage capture here must fail loud NOW, not
+# surface later as a silent fail-open in the marker re-bind guard.
+printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || \
+  { echo "FATAL: could not capture reviewed head SHA ('$REVIEWED_HEAD_SHA')" >&2; exit 1; }
 
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
@@ -1001,19 +1005,40 @@ Field rules:
 3. Derive the marker head with the docs-only guard:
 
 ```bash
-MARKER_HEAD="$REVIEWED_HEAD_SHA"
-CURRENT_HEAD=$(git rev-parse HEAD)
-if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+MARKER_HEAD=""
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+# Both SHAs must be valid 40-hex BEFORE any diff. An empty/unset REVIEWED_HEAD_SHA
+# makes `git diff ""..HEAD` print NOTHING and the guard would fail OPEN (verified);
+# an unresolvable SHA makes git exit 128 with empty stdout — same silent fail-open
+# if the exit code is swallowed by a pipeline. Fail loud on both.
+if ! printf '%s' "$CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: could not resolve local HEAD ('$CURRENT_HEAD') — marker NOT emitted" >&2
+elif ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [ "$CURRENT_HEAD" = "$REVIEWED_HEAD_SHA" ]; then
+  MARKER_HEAD="$REVIEWED_HEAD_SHA"   # no advance — bind to the reviewed head as before
+else
   # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
   # between touches nothing but .prp-output/ (this workflow's own artifacts).
-  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
-  if [ -z "$NON_ARTIFACT" ]; then
-    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  # --no-renames: with rename detection, `git mv src/x .prp-output/y` would show
+  # ONLY the .prp-output destination and a reviewed file could vanish from the
+  # merged tree unnoticed; --no-renames lists BOTH the deletion and the addition.
+  # Capture git diff's exit code SEPARATELY from the grep filter — a git error
+  # must never be indistinguishable from "zero non-artifact files".
+  DIFF_OUTPUT=$(git diff --no-renames "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only 2>&1)
+  DIFF_EC=$?
+  if [ "$DIFF_EC" -ne 0 ]; then
+    echo "FATAL: git diff $REVIEWED_HEAD_SHA..$CURRENT_HEAD failed (exit $DIFF_EC) — cannot verify docs-only advance, refusing to re-bind:" >&2
+    echo "$DIFF_OUTPUT" >&2
   else
-    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
-    echo "$NON_ARTIFACT" >&2
-    echo "Marker NOT emitted — re-run the review against the new head." >&2
-    MARKER_HEAD=""
+    NON_ARTIFACT=$(printf '%s\n' "$DIFF_OUTPUT" | grep -v '^\.prp-output/' || true)
+    if [ -z "$NON_ARTIFACT" ]; then
+      MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+    else
+      echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+      echo "$NON_ARTIFACT" >&2
+      echo "Marker NOT emitted — re-run the review against the new head." >&2
+    fi
   fi
 fi
 ```
@@ -1036,9 +1061,10 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
-# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
-# detected code drift and already reported FATAL.)
+# head must be MARKER_HEAD from the re-bind block above. This regex is a FORMAT
+# backstop only (rejects empty/garbage) — CORRECTNESS of the value is the re-bind
+# guard's job above. (Empty MARKER_HEAD = the guard already reported FATAL:
+# code drift, unresolvable SHA, or git-diff failure.)
 if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then

--- a/adapters/antigravity/prp-review-agents.md
+++ b/adapters/antigravity/prp-review-agents.md
@@ -990,7 +990,38 @@ Field rules:
 - `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
 - `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
 - `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
-- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
+- `head` — use **`$MARKER_HEAD` derived below** (never a fresh `gh pr view`). Default is `$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time, so a push during review invalidates the marker. The ONLY sanctioned exception is the artifacts-commit re-bind in "Commit artifacts BEFORE the marker" below — a docs-only advance of HEAD by this workflow's own artifact commit, mechanically verified.
+
+#### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
+
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+
+1. Write the review artifact (verdict + counts final; **no marker line yet**).
+2. If this flow commits artifacts to the PR branch → `git add`/`commit`/`push` them NOW (review file, fix summaries, reports, archived plan).
+3. Derive the marker head with the docs-only guard:
+
+```bash
+MARKER_HEAD="$REVIEWED_HEAD_SHA"
+CURRENT_HEAD=$(git rev-parse HEAD)
+if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+  # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
+  # between touches nothing but .prp-output/ (this workflow's own artifacts).
+  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
+  if [ -z "$NON_ARTIFACT" ]; then
+    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  else
+    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+    echo "$NON_ARTIFACT" >&2
+    echo "Marker NOT emitted — re-run the review against the new head." >&2
+    MARKER_HEAD=""
+  fi
+fi
+```
+
+4. Emit the marker (below) with `head=$MARKER_HEAD`, append to the artifact, then post to GitHub. The local file's marker may lag one docs-only commit behind its own blob — the GitHub-side post (what `safe-merge` reads for head-matching) carries the current-head binding.
+5. Flows that never commit artifacts to the branch: `MARKER_HEAD` stays `$REVIEWED_HEAD_SHA` — behavior unchanged.
+
+Do NOT commit again after emitting the marker (that re-invalidates it). If a later fix round changes code, the next review round re-runs this whole sequence.
 
 Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
@@ -1005,14 +1036,16 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
-if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
+# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
+# detected code drift and already reported FATAL.)
+if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then
   : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$MARKER_HEAD" \
     >> "$REVIEW_FILE"
 fi
 ```

--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -164,6 +164,10 @@ gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,stat
 # MUST bind to this value — NOT a value re-queried later — so that any push
 # during review invalidates the marker (marker.head != current head → re-review).
 REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# Validate immediately — an empty/garbage capture here must fail loud NOW, not
+# surface later as a silent fail-open in the marker re-bind guard.
+printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || \
+  { echo "FATAL: could not capture reviewed head SHA ('$REVIEWED_HEAD_SHA')" >&2; exit 1; }
 
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
@@ -1003,19 +1007,40 @@ Field rules:
 3. Derive the marker head with the docs-only guard:
 
 ```bash
-MARKER_HEAD="$REVIEWED_HEAD_SHA"
-CURRENT_HEAD=$(git rev-parse HEAD)
-if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+MARKER_HEAD=""
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+# Both SHAs must be valid 40-hex BEFORE any diff. An empty/unset REVIEWED_HEAD_SHA
+# makes `git diff ""..HEAD` print NOTHING and the guard would fail OPEN (verified);
+# an unresolvable SHA makes git exit 128 with empty stdout — same silent fail-open
+# if the exit code is swallowed by a pipeline. Fail loud on both.
+if ! printf '%s' "$CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: could not resolve local HEAD ('$CURRENT_HEAD') — marker NOT emitted" >&2
+elif ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [ "$CURRENT_HEAD" = "$REVIEWED_HEAD_SHA" ]; then
+  MARKER_HEAD="$REVIEWED_HEAD_SHA"   # no advance — bind to the reviewed head as before
+else
   # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
   # between touches nothing but .prp-output/ (this workflow's own artifacts).
-  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
-  if [ -z "$NON_ARTIFACT" ]; then
-    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  # --no-renames: with rename detection, `git mv src/x .prp-output/y` would show
+  # ONLY the .prp-output destination and a reviewed file could vanish from the
+  # merged tree unnoticed; --no-renames lists BOTH the deletion and the addition.
+  # Capture git diff's exit code SEPARATELY from the grep filter — a git error
+  # must never be indistinguishable from "zero non-artifact files".
+  DIFF_OUTPUT=$(git diff --no-renames "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only 2>&1)
+  DIFF_EC=$?
+  if [ "$DIFF_EC" -ne 0 ]; then
+    echo "FATAL: git diff $REVIEWED_HEAD_SHA..$CURRENT_HEAD failed (exit $DIFF_EC) — cannot verify docs-only advance, refusing to re-bind:" >&2
+    echo "$DIFF_OUTPUT" >&2
   else
-    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
-    echo "$NON_ARTIFACT" >&2
-    echo "Marker NOT emitted — re-run the review against the new head." >&2
-    MARKER_HEAD=""
+    NON_ARTIFACT=$(printf '%s\n' "$DIFF_OUTPUT" | grep -v '^\.prp-output/' || true)
+    if [ -z "$NON_ARTIFACT" ]; then
+      MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+    else
+      echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+      echo "$NON_ARTIFACT" >&2
+      echo "Marker NOT emitted — re-run the review against the new head." >&2
+    fi
   fi
 fi
 ```
@@ -1038,9 +1063,10 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
-# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
-# detected code drift and already reported FATAL.)
+# head must be MARKER_HEAD from the re-bind block above. This regex is a FORMAT
+# backstop only (rejects empty/garbage) — CORRECTNESS of the value is the re-bind
+# guard's job above. (Empty MARKER_HEAD = the guard already reported FATAL:
+# code drift, unresolvable SHA, or git-diff failure.)
 if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then

--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -992,7 +992,38 @@ Field rules:
 - `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
 - `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
 - `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
-- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
+- `head` — use **`$MARKER_HEAD` derived below** (never a fresh `gh pr view`). Default is `$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time, so a push during review invalidates the marker. The ONLY sanctioned exception is the artifacts-commit re-bind in "Commit artifacts BEFORE the marker" below — a docs-only advance of HEAD by this workflow's own artifact commit, mechanically verified.
+
+#### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
+
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+
+1. Write the review artifact (verdict + counts final; **no marker line yet**).
+2. If this flow commits artifacts to the PR branch → `git add`/`commit`/`push` them NOW (review file, fix summaries, reports, archived plan).
+3. Derive the marker head with the docs-only guard:
+
+```bash
+MARKER_HEAD="$REVIEWED_HEAD_SHA"
+CURRENT_HEAD=$(git rev-parse HEAD)
+if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+  # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
+  # between touches nothing but .prp-output/ (this workflow's own artifacts).
+  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
+  if [ -z "$NON_ARTIFACT" ]; then
+    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  else
+    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+    echo "$NON_ARTIFACT" >&2
+    echo "Marker NOT emitted — re-run the review against the new head." >&2
+    MARKER_HEAD=""
+  fi
+fi
+```
+
+4. Emit the marker (below) with `head=$MARKER_HEAD`, append to the artifact, then post to GitHub. The local file's marker may lag one docs-only commit behind its own blob — the GitHub-side post (what `safe-merge` reads for head-matching) carries the current-head binding.
+5. Flows that never commit artifacts to the branch: `MARKER_HEAD` stays `$REVIEWED_HEAD_SHA` — behavior unchanged.
+
+Do NOT commit again after emitting the marker (that re-invalidates it). If a later fix round changes code, the next review round re-runs this whole sequence.
 
 Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
@@ -1007,14 +1038,16 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
-if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
+# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
+# detected code drift and already reported FATAL.)
+if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then
   : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$MARKER_HEAD" \
     >> "$REVIEW_FILE"
 fi
 ```

--- a/adapters/codex/prp-review-agents/SKILL.md
+++ b/adapters/codex/prp-review-agents/SKILL.md
@@ -165,6 +165,10 @@ gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,stat
 # MUST bind to this value — NOT a value re-queried later — so that any push
 # during review invalidates the marker (marker.head != current head → re-review).
 REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# Validate immediately — an empty/garbage capture here must fail loud NOW, not
+# surface later as a silent fail-open in the marker re-bind guard.
+printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || \
+  { echo "FATAL: could not capture reviewed head SHA ('$REVIEWED_HEAD_SHA')" >&2; exit 1; }
 
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
@@ -1004,19 +1008,40 @@ Field rules:
 3. Derive the marker head with the docs-only guard:
 
 ```bash
-MARKER_HEAD="$REVIEWED_HEAD_SHA"
-CURRENT_HEAD=$(git rev-parse HEAD)
-if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+MARKER_HEAD=""
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+# Both SHAs must be valid 40-hex BEFORE any diff. An empty/unset REVIEWED_HEAD_SHA
+# makes `git diff ""..HEAD` print NOTHING and the guard would fail OPEN (verified);
+# an unresolvable SHA makes git exit 128 with empty stdout — same silent fail-open
+# if the exit code is swallowed by a pipeline. Fail loud on both.
+if ! printf '%s' "$CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: could not resolve local HEAD ('$CURRENT_HEAD') — marker NOT emitted" >&2
+elif ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [ "$CURRENT_HEAD" = "$REVIEWED_HEAD_SHA" ]; then
+  MARKER_HEAD="$REVIEWED_HEAD_SHA"   # no advance — bind to the reviewed head as before
+else
   # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
   # between touches nothing but .prp-output/ (this workflow's own artifacts).
-  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
-  if [ -z "$NON_ARTIFACT" ]; then
-    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  # --no-renames: with rename detection, `git mv src/x .prp-output/y` would show
+  # ONLY the .prp-output destination and a reviewed file could vanish from the
+  # merged tree unnoticed; --no-renames lists BOTH the deletion and the addition.
+  # Capture git diff's exit code SEPARATELY from the grep filter — a git error
+  # must never be indistinguishable from "zero non-artifact files".
+  DIFF_OUTPUT=$(git diff --no-renames "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only 2>&1)
+  DIFF_EC=$?
+  if [ "$DIFF_EC" -ne 0 ]; then
+    echo "FATAL: git diff $REVIEWED_HEAD_SHA..$CURRENT_HEAD failed (exit $DIFF_EC) — cannot verify docs-only advance, refusing to re-bind:" >&2
+    echo "$DIFF_OUTPUT" >&2
   else
-    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
-    echo "$NON_ARTIFACT" >&2
-    echo "Marker NOT emitted — re-run the review against the new head." >&2
-    MARKER_HEAD=""
+    NON_ARTIFACT=$(printf '%s\n' "$DIFF_OUTPUT" | grep -v '^\.prp-output/' || true)
+    if [ -z "$NON_ARTIFACT" ]; then
+      MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+    else
+      echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+      echo "$NON_ARTIFACT" >&2
+      echo "Marker NOT emitted — re-run the review against the new head." >&2
+    fi
   fi
 fi
 ```
@@ -1039,9 +1064,10 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
-# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
-# detected code drift and already reported FATAL.)
+# head must be MARKER_HEAD from the re-bind block above. This regex is a FORMAT
+# backstop only (rejects empty/garbage) — CORRECTNESS of the value is the re-bind
+# guard's job above. (Empty MARKER_HEAD = the guard already reported FATAL:
+# code drift, unresolvable SHA, or git-diff failure.)
 if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then

--- a/adapters/codex/prp-review-agents/SKILL.md
+++ b/adapters/codex/prp-review-agents/SKILL.md
@@ -993,7 +993,38 @@ Field rules:
 - `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
 - `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
 - `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
-- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
+- `head` — use **`$MARKER_HEAD` derived below** (never a fresh `gh pr view`). Default is `$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time, so a push during review invalidates the marker. The ONLY sanctioned exception is the artifacts-commit re-bind in "Commit artifacts BEFORE the marker" below — a docs-only advance of HEAD by this workflow's own artifact commit, mechanically verified.
+
+#### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
+
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+
+1. Write the review artifact (verdict + counts final; **no marker line yet**).
+2. If this flow commits artifacts to the PR branch → `git add`/`commit`/`push` them NOW (review file, fix summaries, reports, archived plan).
+3. Derive the marker head with the docs-only guard:
+
+```bash
+MARKER_HEAD="$REVIEWED_HEAD_SHA"
+CURRENT_HEAD=$(git rev-parse HEAD)
+if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+  # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
+  # between touches nothing but .prp-output/ (this workflow's own artifacts).
+  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
+  if [ -z "$NON_ARTIFACT" ]; then
+    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  else
+    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+    echo "$NON_ARTIFACT" >&2
+    echo "Marker NOT emitted — re-run the review against the new head." >&2
+    MARKER_HEAD=""
+  fi
+fi
+```
+
+4. Emit the marker (below) with `head=$MARKER_HEAD`, append to the artifact, then post to GitHub. The local file's marker may lag one docs-only commit behind its own blob — the GitHub-side post (what `safe-merge` reads for head-matching) carries the current-head binding.
+5. Flows that never commit artifacts to the branch: `MARKER_HEAD` stays `$REVIEWED_HEAD_SHA` — behavior unchanged.
+
+Do NOT commit again after emitting the marker (that re-invalidates it). If a later fix round changes code, the next review round re-runs this whole sequence.
 
 Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
@@ -1008,14 +1039,16 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
-if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
+# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
+# detected code drift and already reported FATAL.)
+if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then
   : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$MARKER_HEAD" \
     >> "$REVIEW_FILE"
 fi
 ```

--- a/adapters/gemini/review-agents.toml
+++ b/adapters/gemini/review-agents.toml
@@ -161,6 +161,10 @@ gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,stat
 # MUST bind to this value — NOT a value re-queried later — so that any push
 # during review invalidates the marker (marker.head != current head → re-review).
 REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# Validate immediately — an empty/garbage capture here must fail loud NOW, not
+# surface later as a silent fail-open in the marker re-bind guard.
+printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || \\
+  { echo "FATAL: could not capture reviewed head SHA ('$REVIEWED_HEAD_SHA')" >&2; exit 1; }
 
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
@@ -1000,19 +1004,40 @@ Field rules:
 3. Derive the marker head with the docs-only guard:
 
 ```bash
-MARKER_HEAD="$REVIEWED_HEAD_SHA"
-CURRENT_HEAD=$(git rev-parse HEAD)
-if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+MARKER_HEAD=""
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+# Both SHAs must be valid 40-hex BEFORE any diff. An empty/unset REVIEWED_HEAD_SHA
+# makes `git diff ""..HEAD` print NOTHING and the guard would fail OPEN (verified);
+# an unresolvable SHA makes git exit 128 with empty stdout — same silent fail-open
+# if the exit code is swallowed by a pipeline. Fail loud on both.
+if ! printf '%s' "$CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: could not resolve local HEAD ('$CURRENT_HEAD') — marker NOT emitted" >&2
+elif ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [ "$CURRENT_HEAD" = "$REVIEWED_HEAD_SHA" ]; then
+  MARKER_HEAD="$REVIEWED_HEAD_SHA"   # no advance — bind to the reviewed head as before
+else
   # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
   # between touches nothing but .prp-output/ (this workflow's own artifacts).
-  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\\.prp-output/' || true)
-  if [ -z "$NON_ARTIFACT" ]; then
-    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  # --no-renames: with rename detection, `git mv src/x .prp-output/y` would show
+  # ONLY the .prp-output destination and a reviewed file could vanish from the
+  # merged tree unnoticed; --no-renames lists BOTH the deletion and the addition.
+  # Capture git diff's exit code SEPARATELY from the grep filter — a git error
+  # must never be indistinguishable from "zero non-artifact files".
+  DIFF_OUTPUT=$(git diff --no-renames "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only 2>&1)
+  DIFF_EC=$?
+  if [ "$DIFF_EC" -ne 0 ]; then
+    echo "FATAL: git diff $REVIEWED_HEAD_SHA..$CURRENT_HEAD failed (exit $DIFF_EC) — cannot verify docs-only advance, refusing to re-bind:" >&2
+    echo "$DIFF_OUTPUT" >&2
   else
-    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
-    echo "$NON_ARTIFACT" >&2
-    echo "Marker NOT emitted — re-run the review against the new head." >&2
-    MARKER_HEAD=""
+    NON_ARTIFACT=$(printf '%s\\n' "$DIFF_OUTPUT" | grep -v '^\\.prp-output/' || true)
+    if [ -z "$NON_ARTIFACT" ]; then
+      MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+    else
+      echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+      echo "$NON_ARTIFACT" >&2
+      echo "Marker NOT emitted — re-run the review against the new head." >&2
+    fi
   fi
 fi
 ```
@@ -1035,9 +1060,10 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
-# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
-# detected code drift and already reported FATAL.)
+# head must be MARKER_HEAD from the re-bind block above. This regex is a FORMAT
+# backstop only (rejects empty/garbage) — CORRECTNESS of the value is the re-bind
+# guard's job above. (Empty MARKER_HEAD = the guard already reported FATAL:
+# code drift, unresolvable SHA, or git-diff failure.)
 if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then

--- a/adapters/gemini/review-agents.toml
+++ b/adapters/gemini/review-agents.toml
@@ -989,7 +989,38 @@ Field rules:
 - `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
 - `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
 - `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
-- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
+- `head` — use **`$MARKER_HEAD` derived below** (never a fresh `gh pr view`). Default is `$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time, so a push during review invalidates the marker. The ONLY sanctioned exception is the artifacts-commit re-bind in "Commit artifacts BEFORE the marker" below — a docs-only advance of HEAD by this workflow's own artifact commit, mechanically verified.
+
+#### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
+
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+
+1. Write the review artifact (verdict + counts final; **no marker line yet**).
+2. If this flow commits artifacts to the PR branch → `git add`/`commit`/`push` them NOW (review file, fix summaries, reports, archived plan).
+3. Derive the marker head with the docs-only guard:
+
+```bash
+MARKER_HEAD="$REVIEWED_HEAD_SHA"
+CURRENT_HEAD=$(git rev-parse HEAD)
+if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+  # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
+  # between touches nothing but .prp-output/ (this workflow's own artifacts).
+  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\\.prp-output/' || true)
+  if [ -z "$NON_ARTIFACT" ]; then
+    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  else
+    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+    echo "$NON_ARTIFACT" >&2
+    echo "Marker NOT emitted — re-run the review against the new head." >&2
+    MARKER_HEAD=""
+  fi
+fi
+```
+
+4. Emit the marker (below) with `head=$MARKER_HEAD`, append to the artifact, then post to GitHub. The local file's marker may lag one docs-only commit behind its own blob — the GitHub-side post (what `safe-merge` reads for head-matching) carries the current-head binding.
+5. Flows that never commit artifacts to the branch: `MARKER_HEAD` stays `$REVIEWED_HEAD_SHA` — behavior unchanged.
+
+Do NOT commit again after emitting the marker (that re-invalidates it). If a later fix round changes code, the next review round re-runs this whole sequence.
 
 Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
@@ -1004,14 +1035,16 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
-if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
+# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
+# detected code drift and already reported FATAL.)
+if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then
   : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\\n' \\
-    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \\
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$MARKER_HEAD" \\
     >> "$REVIEW_FILE"
 fi
 ```

--- a/adapters/opencode/review-agents.md
+++ b/adapters/opencode/review-agents.md
@@ -163,6 +163,10 @@ gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,stat
 # MUST bind to this value — NOT a value re-queried later — so that any push
 # during review invalidates the marker (marker.head != current head → re-review).
 REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# Validate immediately — an empty/garbage capture here must fail loud NOW, not
+# surface later as a silent fail-open in the marker re-bind guard.
+printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || \
+  { echo "FATAL: could not capture reviewed head SHA ('$REVIEWED_HEAD_SHA')" >&2; exit 1; }
 
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
@@ -1002,19 +1006,40 @@ Field rules:
 3. Derive the marker head with the docs-only guard:
 
 ```bash
-MARKER_HEAD="$REVIEWED_HEAD_SHA"
-CURRENT_HEAD=$(git rev-parse HEAD)
-if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+MARKER_HEAD=""
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+# Both SHAs must be valid 40-hex BEFORE any diff. An empty/unset REVIEWED_HEAD_SHA
+# makes `git diff ""..HEAD` print NOTHING and the guard would fail OPEN (verified);
+# an unresolvable SHA makes git exit 128 with empty stdout — same silent fail-open
+# if the exit code is swallowed by a pipeline. Fail loud on both.
+if ! printf '%s' "$CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: could not resolve local HEAD ('$CURRENT_HEAD') — marker NOT emitted" >&2
+elif ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [ "$CURRENT_HEAD" = "$REVIEWED_HEAD_SHA" ]; then
+  MARKER_HEAD="$REVIEWED_HEAD_SHA"   # no advance — bind to the reviewed head as before
+else
   # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
   # between touches nothing but .prp-output/ (this workflow's own artifacts).
-  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
-  if [ -z "$NON_ARTIFACT" ]; then
-    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  # --no-renames: with rename detection, `git mv src/x .prp-output/y` would show
+  # ONLY the .prp-output destination and a reviewed file could vanish from the
+  # merged tree unnoticed; --no-renames lists BOTH the deletion and the addition.
+  # Capture git diff's exit code SEPARATELY from the grep filter — a git error
+  # must never be indistinguishable from "zero non-artifact files".
+  DIFF_OUTPUT=$(git diff --no-renames "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only 2>&1)
+  DIFF_EC=$?
+  if [ "$DIFF_EC" -ne 0 ]; then
+    echo "FATAL: git diff $REVIEWED_HEAD_SHA..$CURRENT_HEAD failed (exit $DIFF_EC) — cannot verify docs-only advance, refusing to re-bind:" >&2
+    echo "$DIFF_OUTPUT" >&2
   else
-    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
-    echo "$NON_ARTIFACT" >&2
-    echo "Marker NOT emitted — re-run the review against the new head." >&2
-    MARKER_HEAD=""
+    NON_ARTIFACT=$(printf '%s\n' "$DIFF_OUTPUT" | grep -v '^\.prp-output/' || true)
+    if [ -z "$NON_ARTIFACT" ]; then
+      MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+    else
+      echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+      echo "$NON_ARTIFACT" >&2
+      echo "Marker NOT emitted — re-run the review against the new head." >&2
+    fi
   fi
 fi
 ```
@@ -1037,9 +1062,10 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
-# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
-# detected code drift and already reported FATAL.)
+# head must be MARKER_HEAD from the re-bind block above. This regex is a FORMAT
+# backstop only (rejects empty/garbage) — CORRECTNESS of the value is the re-bind
+# guard's job above. (Empty MARKER_HEAD = the guard already reported FATAL:
+# code drift, unresolvable SHA, or git-diff failure.)
 if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then

--- a/adapters/opencode/review-agents.md
+++ b/adapters/opencode/review-agents.md
@@ -991,7 +991,38 @@ Field rules:
 - `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
 - `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
 - `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
-- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
+- `head` — use **`$MARKER_HEAD` derived below** (never a fresh `gh pr view`). Default is `$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time, so a push during review invalidates the marker. The ONLY sanctioned exception is the artifacts-commit re-bind in "Commit artifacts BEFORE the marker" below — a docs-only advance of HEAD by this workflow's own artifact commit, mechanically verified.
+
+#### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
+
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+
+1. Write the review artifact (verdict + counts final; **no marker line yet**).
+2. If this flow commits artifacts to the PR branch → `git add`/`commit`/`push` them NOW (review file, fix summaries, reports, archived plan).
+3. Derive the marker head with the docs-only guard:
+
+```bash
+MARKER_HEAD="$REVIEWED_HEAD_SHA"
+CURRENT_HEAD=$(git rev-parse HEAD)
+if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+  # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
+  # between touches nothing but .prp-output/ (this workflow's own artifacts).
+  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
+  if [ -z "$NON_ARTIFACT" ]; then
+    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  else
+    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+    echo "$NON_ARTIFACT" >&2
+    echo "Marker NOT emitted — re-run the review against the new head." >&2
+    MARKER_HEAD=""
+  fi
+fi
+```
+
+4. Emit the marker (below) with `head=$MARKER_HEAD`, append to the artifact, then post to GitHub. The local file's marker may lag one docs-only commit behind its own blob — the GitHub-side post (what `safe-merge` reads for head-matching) carries the current-head binding.
+5. Flows that never commit artifacts to the branch: `MARKER_HEAD` stays `$REVIEWED_HEAD_SHA` — behavior unchanged.
+
+Do NOT commit again after emitting the marker (that re-invalidates it). If a later fix round changes code, the next review round re-runs this whole sequence.
 
 Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
@@ -1006,14 +1037,16 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
-if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
+# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
+# detected code drift and already reported FATAL.)
+if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then
   : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$MARKER_HEAD" \
     >> "$REVIEW_FILE"
 fi
 ```

--- a/adapters/thclaws/prp-review-agents/SKILL.md
+++ b/adapters/thclaws/prp-review-agents/SKILL.md
@@ -165,6 +165,10 @@ gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,stat
 # MUST bind to this value — NOT a value re-queried later — so that any push
 # during review invalidates the marker (marker.head != current head → re-review).
 REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# Validate immediately — an empty/garbage capture here must fail loud NOW, not
+# surface later as a silent fail-open in the marker re-bind guard.
+printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || \
+  { echo "FATAL: could not capture reviewed head SHA ('$REVIEWED_HEAD_SHA')" >&2; exit 1; }
 
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
@@ -1004,19 +1008,40 @@ Field rules:
 3. Derive the marker head with the docs-only guard:
 
 ```bash
-MARKER_HEAD="$REVIEWED_HEAD_SHA"
-CURRENT_HEAD=$(git rev-parse HEAD)
-if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+MARKER_HEAD=""
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+# Both SHAs must be valid 40-hex BEFORE any diff. An empty/unset REVIEWED_HEAD_SHA
+# makes `git diff ""..HEAD` print NOTHING and the guard would fail OPEN (verified);
+# an unresolvable SHA makes git exit 128 with empty stdout — same silent fail-open
+# if the exit code is swallowed by a pipeline. Fail loud on both.
+if ! printf '%s' "$CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: could not resolve local HEAD ('$CURRENT_HEAD') — marker NOT emitted" >&2
+elif ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [ "$CURRENT_HEAD" = "$REVIEWED_HEAD_SHA" ]; then
+  MARKER_HEAD="$REVIEWED_HEAD_SHA"   # no advance — bind to the reviewed head as before
+else
   # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
   # between touches nothing but .prp-output/ (this workflow's own artifacts).
-  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
-  if [ -z "$NON_ARTIFACT" ]; then
-    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  # --no-renames: with rename detection, `git mv src/x .prp-output/y` would show
+  # ONLY the .prp-output destination and a reviewed file could vanish from the
+  # merged tree unnoticed; --no-renames lists BOTH the deletion and the addition.
+  # Capture git diff's exit code SEPARATELY from the grep filter — a git error
+  # must never be indistinguishable from "zero non-artifact files".
+  DIFF_OUTPUT=$(git diff --no-renames "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only 2>&1)
+  DIFF_EC=$?
+  if [ "$DIFF_EC" -ne 0 ]; then
+    echo "FATAL: git diff $REVIEWED_HEAD_SHA..$CURRENT_HEAD failed (exit $DIFF_EC) — cannot verify docs-only advance, refusing to re-bind:" >&2
+    echo "$DIFF_OUTPUT" >&2
   else
-    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
-    echo "$NON_ARTIFACT" >&2
-    echo "Marker NOT emitted — re-run the review against the new head." >&2
-    MARKER_HEAD=""
+    NON_ARTIFACT=$(printf '%s\n' "$DIFF_OUTPUT" | grep -v '^\.prp-output/' || true)
+    if [ -z "$NON_ARTIFACT" ]; then
+      MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+    else
+      echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+      echo "$NON_ARTIFACT" >&2
+      echo "Marker NOT emitted — re-run the review against the new head." >&2
+    fi
   fi
 fi
 ```
@@ -1039,9 +1064,10 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
-# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
-# detected code drift and already reported FATAL.)
+# head must be MARKER_HEAD from the re-bind block above. This regex is a FORMAT
+# backstop only (rejects empty/garbage) — CORRECTNESS of the value is the re-bind
+# guard's job above. (Empty MARKER_HEAD = the guard already reported FATAL:
+# code drift, unresolvable SHA, or git-diff failure.)
 if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then

--- a/adapters/thclaws/prp-review-agents/SKILL.md
+++ b/adapters/thclaws/prp-review-agents/SKILL.md
@@ -993,7 +993,38 @@ Field rules:
 - `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
 - `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
 - `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
-- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
+- `head` — use **`$MARKER_HEAD` derived below** (never a fresh `gh pr view`). Default is `$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time, so a push during review invalidates the marker. The ONLY sanctioned exception is the artifacts-commit re-bind in "Commit artifacts BEFORE the marker" below — a docs-only advance of HEAD by this workflow's own artifact commit, mechanically verified.
+
+#### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
+
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+
+1. Write the review artifact (verdict + counts final; **no marker line yet**).
+2. If this flow commits artifacts to the PR branch → `git add`/`commit`/`push` them NOW (review file, fix summaries, reports, archived plan).
+3. Derive the marker head with the docs-only guard:
+
+```bash
+MARKER_HEAD="$REVIEWED_HEAD_SHA"
+CURRENT_HEAD=$(git rev-parse HEAD)
+if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+  # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
+  # between touches nothing but .prp-output/ (this workflow's own artifacts).
+  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
+  if [ -z "$NON_ARTIFACT" ]; then
+    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  else
+    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+    echo "$NON_ARTIFACT" >&2
+    echo "Marker NOT emitted — re-run the review against the new head." >&2
+    MARKER_HEAD=""
+  fi
+fi
+```
+
+4. Emit the marker (below) with `head=$MARKER_HEAD`, append to the artifact, then post to GitHub. The local file's marker may lag one docs-only commit behind its own blob — the GitHub-side post (what `safe-merge` reads for head-matching) carries the current-head binding.
+5. Flows that never commit artifacts to the branch: `MARKER_HEAD` stays `$REVIEWED_HEAD_SHA` — behavior unchanged.
+
+Do NOT commit again after emitting the marker (that re-invalidates it). If a later fix round changes code, the next review round re-runs this whole sequence.
 
 Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
@@ -1008,14 +1039,16 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
-if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
+# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
+# detected code drift and already reported FATAL.)
+if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then
   : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$MARKER_HEAD" \
     >> "$REVIEW_FILE"
 fi
 ```

--- a/prompts/review-agents.md
+++ b/prompts/review-agents.md
@@ -159,6 +159,10 @@ gh pr view {NUMBER} --json number,title,body,author,headRefName,baseRefName,stat
 # MUST bind to this value — NOT a value re-queried later — so that any push
 # during review invalidates the marker (marker.head != current head → re-review).
 REVIEWED_HEAD_SHA=$(gh pr view {NUMBER} --json headRefOid -q '.headRefOid')
+# Validate immediately — an empty/garbage capture here must fail loud NOW, not
+# surface later as a silent fail-open in the marker re-bind guard.
+printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$' || \
+  { echo "FATAL: could not capture reviewed head SHA ('$REVIEWED_HEAD_SHA')" >&2; exit 1; }
 
 # Structural diff (compact overview — for agent routing)
 # Use prp-diff if available, otherwise fall back to gh pr diff
@@ -998,19 +1002,40 @@ Field rules:
 3. Derive the marker head with the docs-only guard:
 
 ```bash
-MARKER_HEAD="$REVIEWED_HEAD_SHA"
-CURRENT_HEAD=$(git rev-parse HEAD)
-if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+MARKER_HEAD=""
+CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+# Both SHAs must be valid 40-hex BEFORE any diff. An empty/unset REVIEWED_HEAD_SHA
+# makes `git diff ""..HEAD` print NOTHING and the guard would fail OPEN (verified);
+# an unresolvable SHA makes git exit 128 with empty stdout — same silent fail-open
+# if the exit code is swallowed by a pipeline. Fail loud on both.
+if ! printf '%s' "$CURRENT_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: could not resolve local HEAD ('$CURRENT_HEAD') — marker NOT emitted" >&2
+elif ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+elif [ "$CURRENT_HEAD" = "$REVIEWED_HEAD_SHA" ]; then
+  MARKER_HEAD="$REVIEWED_HEAD_SHA"   # no advance — bind to the reviewed head as before
+else
   # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
   # between touches nothing but .prp-output/ (this workflow's own artifacts).
-  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
-  if [ -z "$NON_ARTIFACT" ]; then
-    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  # --no-renames: with rename detection, `git mv src/x .prp-output/y` would show
+  # ONLY the .prp-output destination and a reviewed file could vanish from the
+  # merged tree unnoticed; --no-renames lists BOTH the deletion and the addition.
+  # Capture git diff's exit code SEPARATELY from the grep filter — a git error
+  # must never be indistinguishable from "zero non-artifact files".
+  DIFF_OUTPUT=$(git diff --no-renames "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only 2>&1)
+  DIFF_EC=$?
+  if [ "$DIFF_EC" -ne 0 ]; then
+    echo "FATAL: git diff $REVIEWED_HEAD_SHA..$CURRENT_HEAD failed (exit $DIFF_EC) — cannot verify docs-only advance, refusing to re-bind:" >&2
+    echo "$DIFF_OUTPUT" >&2
   else
-    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
-    echo "$NON_ARTIFACT" >&2
-    echo "Marker NOT emitted — re-run the review against the new head." >&2
-    MARKER_HEAD=""
+    NON_ARTIFACT=$(printf '%s\n' "$DIFF_OUTPUT" | grep -v '^\.prp-output/' || true)
+    if [ -z "$NON_ARTIFACT" ]; then
+      MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+    else
+      echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+      echo "$NON_ARTIFACT" >&2
+      echo "Marker NOT emitted — re-run the review against the new head." >&2
+    fi
   fi
 fi
 ```
@@ -1033,9 +1058,10 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
-# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
-# detected code drift and already reported FATAL.)
+# head must be MARKER_HEAD from the re-bind block above. This regex is a FORMAT
+# backstop only (rejects empty/garbage) — CORRECTNESS of the value is the re-bind
+# guard's job above. (Empty MARKER_HEAD = the guard already reported FATAL:
+# code drift, unresolvable SHA, or git-diff failure.)
 if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
   echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then

--- a/prompts/review-agents.md
+++ b/prompts/review-agents.md
@@ -987,7 +987,38 @@ Field rules:
 - `verdict` — map the aggregated verdict: `READY TO MERGE`→`READY_TO_MERGE`, `NEEDS FIXES`→`NEEDS_FIXES`, `CRITICAL ISSUES`→`CRITICAL_ISSUES`. **The verdict field is authoritative for block/pass:** `safe-merge` blocks on `NEEDS_FIXES`/`CRITICAL_ISSUES` regardless of counts (so a `CRITICAL_ISSUES` caused by a validation/build failure with zero agent-critical findings — see the Verdict Decision Logic — is legitimately `critical=0` and still blocks).
 - `critical` / `important` — MUST equal the integers in the body headings `### Critical Issues (N found)` / `### Important Issues (N found)`. `safe-merge` recomputes them from the body and BLOCKS on mismatch. Only enforced invariant: `READY_TO_MERGE` ⟹ `critical=0` AND `important=0`. (No `critical>0` requirement for `CRITICAL_ISSUES` — a blocking verdict already blocks.)
 - `agents` — comma-separated `[a-z0-9-]` tokens, no spaces. **Do NOT emit `verdict=READY_TO_MERGE` unless all three core agents (`code-reviewer`, `security-reviewer`, `silent-failure-hunter`) are present in the aggregation** — mirrors the Phase 3 rule "READY TO MERGE is never valid when a core agent is missing." If a core agent is missing, the verdict is at least `NEEDS_FIXES`.
-- `head` — reuse **`$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time** (NOT a fresh `gh pr view`). This binds the marker to the exact commit the agents reviewed, so a push during review invalidates it.
+- `head` — use **`$MARKER_HEAD` derived below** (never a fresh `gh pr view`). Default is `$REVIEWED_HEAD_SHA` captured in Phase 1.3 at diff-gather time, so a push during review invalidates the marker. The ONLY sanctioned exception is the artifacts-commit re-bind in "Commit artifacts BEFORE the marker" below — a docs-only advance of HEAD by this workflow's own artifact commit, mechanically verified.
+
+#### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
+
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+
+1. Write the review artifact (verdict + counts final; **no marker line yet**).
+2. If this flow commits artifacts to the PR branch → `git add`/`commit`/`push` them NOW (review file, fix summaries, reports, archived plan).
+3. Derive the marker head with the docs-only guard:
+
+```bash
+MARKER_HEAD="$REVIEWED_HEAD_SHA"
+CURRENT_HEAD=$(git rev-parse HEAD)
+if [ "$CURRENT_HEAD" != "$REVIEWED_HEAD_SHA" ]; then
+  # HEAD moved since diff-gather. Re-bind is legitimate ONLY if every commit in
+  # between touches nothing but .prp-output/ (this workflow's own artifacts).
+  NON_ARTIFACT=$(git diff "$REVIEWED_HEAD_SHA".."$CURRENT_HEAD" --name-only | grep -v '^\.prp-output/' || true)
+  if [ -z "$NON_ARTIFACT" ]; then
+    MARKER_HEAD="$CURRENT_HEAD"   # docs-only advance — reviewed code state is byte-identical
+  else
+    echo "FATAL: code changed since review ($REVIEWED_HEAD_SHA -> $CURRENT_HEAD):" >&2
+    echo "$NON_ARTIFACT" >&2
+    echo "Marker NOT emitted — re-run the review against the new head." >&2
+    MARKER_HEAD=""
+  fi
+fi
+```
+
+4. Emit the marker (below) with `head=$MARKER_HEAD`, append to the artifact, then post to GitHub. The local file's marker may lag one docs-only commit behind its own blob — the GitHub-side post (what `safe-merge` reads for head-matching) carries the current-head binding.
+5. Flows that never commit artifacts to the branch: `MARKER_HEAD` stays `$REVIEWED_HEAD_SHA` — behavior unchanged.
+
+Do NOT commit again after emitting the marker (that re-invalidates it). If a later fix round changes code, the next review round re-runs this whole sequence.
 
 Extract the counts **mechanically from the file you just wrote** (don't retype from memory — that drifts, and a drift makes `safe-merge` block):
 ```bash
@@ -1002,14 +1033,16 @@ case "$VERDICT_TOKEN" in
   READY_TO_MERGE|NEEDS_FIXES|CRITICAL_ISSUES) ;;
   *) echo "FATAL: bad VERDICT_TOKEN ('$VERDICT_TOKEN') — marker NOT emitted" >&2; VERDICT_TOKEN="" ;;
 esac
-# head must be the Phase-1 reviewed SHA, validated as 40-hex — fail loud, never emit a malformed marker.
-if ! printf '%s' "$REVIEWED_HEAD_SHA" | grep -qE '^[0-9a-f]{40}$'; then
-  echo "FATAL: REVIEWED_HEAD_SHA missing/invalid ('$REVIEWED_HEAD_SHA') — marker NOT emitted; re-run Phase 1.3" >&2
+# head must be MARKER_HEAD from the re-bind block above, validated as 40-hex —
+# fail loud, never emit a malformed marker. (Empty MARKER_HEAD = re-bind guard
+# detected code drift and already reported FATAL.)
+if ! printf '%s' "$MARKER_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "FATAL: MARKER_HEAD missing/invalid ('$MARKER_HEAD') — marker NOT emitted; re-run Phase 1.3 / the re-bind block" >&2
 elif [[ -z "$VERDICT_TOKEN" ]]; then
   : # VERDICT_TOKEN already reported FATAL above — marker not emitted
 else
   printf '\n<!-- safe-merge-review: verdict=%s critical=%s important=%s agents=%s head=%s -->\n' \
-    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$REVIEWED_HEAD_SHA" \
+    "$VERDICT_TOKEN" "$CRIT" "$IMP" "$AGENTS_CSV" "$MARKER_HEAD" \
     >> "$REVIEW_FILE"
 fi
 ```


### PR DESCRIPTION
## Summary

Fixes #121 — the skill's own two requirements contradicted each other: the safe-merge marker binds to the reviewed HEAD, but the artifacts commit the workflow also requires advances HEAD past that SHA, guaranteeing a merge-time block on every compliant PR (and inviting `--skip-review-check`).

## Change (canonical prompt + 6 regenerated adapters)

New subsection **"Commit artifacts BEFORE the marker (head re-bind)"** in `prompts/review-agents.md`, establishing fixed ordering:

1. Write review artifact (verdict/counts final, no marker line)
2. Commit + push artifacts to the PR branch (flows that do so)
3. Derive `MARKER_HEAD`: default `REVIEWED_HEAD_SHA`; if HEAD moved, re-bind to current head **only** when `git diff reviewed..current --name-only` contains exclusively `.prp-output/` paths — any other path = code drift = FATAL, marker not emitted, re-review required
4. Emit marker at `MARKER_HEAD`, post to GitHub; never commit after the marker
5. Non-artifact-committing flows: behavior unchanged

The `head` field rule and the emit-block validation now reference `MARKER_HEAD` (fail-loud on empty/malformed, same as before).

## Validation

| Check | Result |
|-------|--------|
| `generate-adapters.py` | 6 generated, 0 errors; idempotent on re-run (0 changes) |
| `tests/adapters/parity.bats` | 99 ok |
| Marker bash snippet | `bash -n` clean |

## Trust model unchanged

Re-bind is an integrity convenience for the honest reviewer, not an authenticity change: the docs-only guard is mechanical, and safe-merge still re-derives counts from the body and blocks on any inconsistency. A dishonest process could always forge body+marker — same as before (#785 trust note retained verbatim).

Refs: observed live on clienta.ai PR #1910/#1911 (2026-07-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)