### PR TITLE
docs(review-agents): warn that committing the artifact dismisses code-owner approval

### DIFF
--- a/adapters/antigravity/prp-review-agents.md
+++ b/adapters/antigravity/prp-review-agents.md
@@ -1045,8 +1045,19 @@ approved, the artifact commit landed, and `reviewDecision` went straight back to
 This makes the ordering below load-bearing in both directions. Commit artifacts
 BEFORE requesting review, or do not commit them at all — posting the artifact as
 a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
-travels in the comment body. When in doubt, prefer the comment: it cannot
-dismiss an approval, and it cannot advance HEAD.
+travels in the comment body.
+
+Neither option is free. A committed artifact is in git history and cannot be
+quietly altered later; a PR comment can be edited or deleted by its author, so
+choosing the comment trades an immutable audit record for the ordering fix — if
+a later gate-audit or retro needs to read that review, commit it (before
+requesting approval) rather than comment it. On a PUBLIC repo the comment path
+also widens the marker's practical author set from "collaborators with push
+access" to "any GitHub account". That stays within the marker's documented bar
+— it is explicitly an integrity and head-binding signal, not an authenticity
+boundary, and `safe-merge` still re-derives the counts, re-checks the head SHA
+and fails closed — but it is a real difference and should be a deliberate
+choice, not a default.
 
 Fixed ordering:
 

--- a/adapters/antigravity/prp-review-agents.md
+++ b/adapters/antigravity/prp-review-agents.md
@@ -1031,7 +1031,24 @@ Field rules:
 
 #### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
 
-`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate.
+
+**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
+When branch protection has it enabled, ANY push to the PR branch — including a
+docs-only artifact commit — silently discards every approval already given. So
+committing the artifact after a code owner has approved does not merely
+invalidate the marker; it revokes the approval and forces a second review round
+for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
+approved, the artifact commit landed, and `reviewDecision` went straight back to
+`REVIEW_REQUIRED`.
+
+This makes the ordering below load-bearing in both directions. Commit artifacts
+BEFORE requesting review, or do not commit them at all — posting the artifact as
+a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
+travels in the comment body. When in doubt, prefer the comment: it cannot
+dismiss an approval, and it cannot advance HEAD.
+
+Fixed ordering:
 
 1. Write the review artifact (verdict + counts final; **no marker line yet**).
 2. Commit artifacts to the PR branch → the "Commit Review Artifact to PR Branch" step above handles `git add`/`commit`/`push` automatically (unless `--no-commit` or `PRP_RUN_ALL`). For run-all / ARTIFACT-REPORT flows, they commit all artifacts together in their own step.

--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -1047,8 +1047,19 @@ approved, the artifact commit landed, and `reviewDecision` went straight back to
 This makes the ordering below load-bearing in both directions. Commit artifacts
 BEFORE requesting review, or do not commit them at all — posting the artifact as
 a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
-travels in the comment body. When in doubt, prefer the comment: it cannot
-dismiss an approval, and it cannot advance HEAD.
+travels in the comment body.
+
+Neither option is free. A committed artifact is in git history and cannot be
+quietly altered later; a PR comment can be edited or deleted by its author, so
+choosing the comment trades an immutable audit record for the ordering fix — if
+a later gate-audit or retro needs to read that review, commit it (before
+requesting approval) rather than comment it. On a PUBLIC repo the comment path
+also widens the marker's practical author set from "collaborators with push
+access" to "any GitHub account". That stays within the marker's documented bar
+— it is explicitly an integrity and head-binding signal, not an authenticity
+boundary, and `safe-merge` still re-derives the counts, re-checks the head SHA
+and fails closed — but it is a real difference and should be a deliberate
+choice, not a default.
 
 Fixed ordering:
 

--- a/adapters/claude-code/prp-review-agents.md
+++ b/adapters/claude-code/prp-review-agents.md
@@ -1033,7 +1033,24 @@ Field rules:
 
 #### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
 
-`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate.
+
+**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
+When branch protection has it enabled, ANY push to the PR branch — including a
+docs-only artifact commit — silently discards every approval already given. So
+committing the artifact after a code owner has approved does not merely
+invalidate the marker; it revokes the approval and forces a second review round
+for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
+approved, the artifact commit landed, and `reviewDecision` went straight back to
+`REVIEW_REQUIRED`.
+
+This makes the ordering below load-bearing in both directions. Commit artifacts
+BEFORE requesting review, or do not commit them at all — posting the artifact as
+a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
+travels in the comment body. When in doubt, prefer the comment: it cannot
+dismiss an approval, and it cannot advance HEAD.
+
+Fixed ordering:
 
 1. Write the review artifact (verdict + counts final; **no marker line yet**).
 2. Commit artifacts to the PR branch → the "Commit Review Artifact to PR Branch" step above handles `git add`/`commit`/`push` automatically (unless `--no-commit` or `PRP_RUN_ALL`). For run-all / ARTIFACT-REPORT flows, they commit all artifacts together in their own step.

--- a/adapters/codex/prp-review-agents/SKILL.md
+++ b/adapters/codex/prp-review-agents/SKILL.md
@@ -1048,23 +1048,19 @@ approved, the artifact commit landed, and `reviewDecision` went straight back to
 This makes the ordering below load-bearing in both directions. Commit artifacts
 BEFORE requesting review, or do not commit them at all — posting the artifact as
 a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
-travels in the comment body. When in doubt, prefer the comment: it cannot
-dismiss an approval, and it cannot advance HEAD.
+travels in the comment body.
 
-**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
-When branch protection has it enabled, ANY push to the PR branch — including a
-docs-only artifact commit — silently discards every approval already given. So
-committing the artifact after a code owner has approved does not merely
-invalidate the marker; it revokes the approval and forces a second review round
-for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
-approved, the artifact commit landed, and `reviewDecision` went straight back to
-`REVIEW_REQUIRED`.
-
-This makes the ordering below load-bearing in both directions. Commit artifacts
-BEFORE requesting review, or do not commit them at all — posting the artifact as
-a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
-travels in the comment body. When in doubt, prefer the comment: it cannot
-dismiss an approval, and it cannot advance HEAD.
+Neither option is free. A committed artifact is in git history and cannot be
+quietly altered later; a PR comment can be edited or deleted by its author, so
+choosing the comment trades an immutable audit record for the ordering fix — if
+a later gate-audit or retro needs to read that review, commit it (before
+requesting approval) rather than comment it. On a PUBLIC repo the comment path
+also widens the marker's practical author set from "collaborators with push
+access" to "any GitHub account". That stays within the marker's documented bar
+— it is explicitly an integrity and head-binding signal, not an authenticity
+boundary, and `safe-merge` still re-derives the counts, re-checks the head SHA
+and fails closed — but it is a real difference and should be a deliberate
+choice, not a default.
 
 Fixed ordering:
 

--- a/adapters/codex/prp-review-agents/SKILL.md
+++ b/adapters/codex/prp-review-agents/SKILL.md
@@ -1034,7 +1034,39 @@ Field rules:
 
 #### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
 
-`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate.
+
+**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
+When branch protection has it enabled, ANY push to the PR branch — including a
+docs-only artifact commit — silently discards every approval already given. So
+committing the artifact after a code owner has approved does not merely
+invalidate the marker; it revokes the approval and forces a second review round
+for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
+approved, the artifact commit landed, and `reviewDecision` went straight back to
+`REVIEW_REQUIRED`.
+
+This makes the ordering below load-bearing in both directions. Commit artifacts
+BEFORE requesting review, or do not commit them at all — posting the artifact as
+a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
+travels in the comment body. When in doubt, prefer the comment: it cannot
+dismiss an approval, and it cannot advance HEAD.
+
+**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
+When branch protection has it enabled, ANY push to the PR branch — including a
+docs-only artifact commit — silently discards every approval already given. So
+committing the artifact after a code owner has approved does not merely
+invalidate the marker; it revokes the approval and forces a second review round
+for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
+approved, the artifact commit landed, and `reviewDecision` went straight back to
+`REVIEW_REQUIRED`.
+
+This makes the ordering below load-bearing in both directions. Commit artifacts
+BEFORE requesting review, or do not commit them at all — posting the artifact as
+a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
+travels in the comment body. When in doubt, prefer the comment: it cannot
+dismiss an approval, and it cannot advance HEAD.
+
+Fixed ordering:
 
 1. Write the review artifact (verdict + counts final; **no marker line yet**).
 2. Commit artifacts to the PR branch → the "Commit Review Artifact to PR Branch" step above handles `git add`/`commit`/`push` automatically (unless `--no-commit` or `PRP_RUN_ALL`). For run-all / ARTIFACT-REPORT flows, they commit all artifacts together in their own step.

--- a/adapters/gemini/review-agents.toml
+++ b/adapters/gemini/review-agents.toml
@@ -1044,8 +1044,19 @@ approved, the artifact commit landed, and `reviewDecision` went straight back to
 This makes the ordering below load-bearing in both directions. Commit artifacts
 BEFORE requesting review, or do not commit them at all — posting the artifact as
 a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
-travels in the comment body. When in doubt, prefer the comment: it cannot
-dismiss an approval, and it cannot advance HEAD.
+travels in the comment body.
+
+Neither option is free. A committed artifact is in git history and cannot be
+quietly altered later; a PR comment can be edited or deleted by its author, so
+choosing the comment trades an immutable audit record for the ordering fix — if
+a later gate-audit or retro needs to read that review, commit it (before
+requesting approval) rather than comment it. On a PUBLIC repo the comment path
+also widens the marker's practical author set from "collaborators with push
+access" to "any GitHub account". That stays within the marker's documented bar
+— it is explicitly an integrity and head-binding signal, not an authenticity
+boundary, and `safe-merge` still re-derives the counts, re-checks the head SHA
+and fails closed — but it is a real difference and should be a deliberate
+choice, not a default.
 
 Fixed ordering:
 

--- a/adapters/gemini/review-agents.toml
+++ b/adapters/gemini/review-agents.toml
@@ -1030,7 +1030,24 @@ Field rules:
 
 #### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
 
-`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate.
+
+**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
+When branch protection has it enabled, ANY push to the PR branch — including a
+docs-only artifact commit — silently discards every approval already given. So
+committing the artifact after a code owner has approved does not merely
+invalidate the marker; it revokes the approval and forces a second review round
+for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
+approved, the artifact commit landed, and `reviewDecision` went straight back to
+`REVIEW_REQUIRED`.
+
+This makes the ordering below load-bearing in both directions. Commit artifacts
+BEFORE requesting review, or do not commit them at all — posting the artifact as
+a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
+travels in the comment body. When in doubt, prefer the comment: it cannot
+dismiss an approval, and it cannot advance HEAD.
+
+Fixed ordering:
 
 1. Write the review artifact (verdict + counts final; **no marker line yet**).
 2. Commit artifacts to the PR branch → the "Commit Review Artifact to PR Branch" step above handles `git add`/`commit`/`push` automatically (unless `--no-commit` or `PRP_RUN_ALL`). For run-all / ARTIFACT-REPORT flows, they commit all artifacts together in their own step.

--- a/adapters/opencode/review-agents.md
+++ b/adapters/opencode/review-agents.md
@@ -1046,8 +1046,19 @@ approved, the artifact commit landed, and `reviewDecision` went straight back to
 This makes the ordering below load-bearing in both directions. Commit artifacts
 BEFORE requesting review, or do not commit them at all — posting the artifact as
 a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
-travels in the comment body. When in doubt, prefer the comment: it cannot
-dismiss an approval, and it cannot advance HEAD.
+travels in the comment body.
+
+Neither option is free. A committed artifact is in git history and cannot be
+quietly altered later; a PR comment can be edited or deleted by its author, so
+choosing the comment trades an immutable audit record for the ordering fix — if
+a later gate-audit or retro needs to read that review, commit it (before
+requesting approval) rather than comment it. On a PUBLIC repo the comment path
+also widens the marker's practical author set from "collaborators with push
+access" to "any GitHub account". That stays within the marker's documented bar
+— it is explicitly an integrity and head-binding signal, not an authenticity
+boundary, and `safe-merge` still re-derives the counts, re-checks the head SHA
+and fails closed — but it is a real difference and should be a deliberate
+choice, not a default.
 
 Fixed ordering:
 

--- a/adapters/opencode/review-agents.md
+++ b/adapters/opencode/review-agents.md
@@ -1032,7 +1032,24 @@ Field rules:
 
 #### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
 
-`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate.
+
+**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
+When branch protection has it enabled, ANY push to the PR branch — including a
+docs-only artifact commit — silently discards every approval already given. So
+committing the artifact after a code owner has approved does not merely
+invalidate the marker; it revokes the approval and forces a second review round
+for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
+approved, the artifact commit landed, and `reviewDecision` went straight back to
+`REVIEW_REQUIRED`.
+
+This makes the ordering below load-bearing in both directions. Commit artifacts
+BEFORE requesting review, or do not commit them at all — posting the artifact as
+a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
+travels in the comment body. When in doubt, prefer the comment: it cannot
+dismiss an approval, and it cannot advance HEAD.
+
+Fixed ordering:
 
 1. Write the review artifact (verdict + counts final; **no marker line yet**).
 2. Commit artifacts to the PR branch → the "Commit Review Artifact to PR Branch" step above handles `git add`/`commit`/`push` automatically (unless `--no-commit` or `PRP_RUN_ALL`). For run-all / ARTIFACT-REPORT flows, they commit all artifacts together in their own step.

--- a/adapters/thclaws/prp-review-agents/SKILL.md
+++ b/adapters/thclaws/prp-review-agents/SKILL.md
@@ -1048,8 +1048,19 @@ approved, the artifact commit landed, and `reviewDecision` went straight back to
 This makes the ordering below load-bearing in both directions. Commit artifacts
 BEFORE requesting review, or do not commit them at all — posting the artifact as
 a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
-travels in the comment body. When in doubt, prefer the comment: it cannot
-dismiss an approval, and it cannot advance HEAD.
+travels in the comment body.
+
+Neither option is free. A committed artifact is in git history and cannot be
+quietly altered later; a PR comment can be edited or deleted by its author, so
+choosing the comment trades an immutable audit record for the ordering fix — if
+a later gate-audit or retro needs to read that review, commit it (before
+requesting approval) rather than comment it. On a PUBLIC repo the comment path
+also widens the marker's practical author set from "collaborators with push
+access" to "any GitHub account". That stays within the marker's documented bar
+— it is explicitly an integrity and head-binding signal, not an authenticity
+boundary, and `safe-merge` still re-derives the counts, re-checks the head SHA
+and fails closed — but it is a real difference and should be a deliberate
+choice, not a default.
 
 Fixed ordering:
 

--- a/adapters/thclaws/prp-review-agents/SKILL.md
+++ b/adapters/thclaws/prp-review-agents/SKILL.md
@@ -1034,7 +1034,24 @@ Field rules:
 
 #### Commit artifacts BEFORE the marker (head re-bind, prp-framework#121)
 
-`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate. Fixed ordering:
+`safe-merge` matches the GitHub-side marker's `head=` against the PR HEAD **at merge time**. Flows that commit review artifacts to the PR branch (run-all, ARTIFACT-REPORT) advance HEAD past `$REVIEWED_HEAD_SHA` with that very commit — a marker bound to the pre-artifacts SHA is then guaranteed to block, and the tempting escape (`--skip-review-check`) defeats the gate.
+
+**A second, independent reason the ordering matters: `dismiss_stale_reviews`.**
+When branch protection has it enabled, ANY push to the PR branch — including a
+docs-only artifact commit — silently discards every approval already given. So
+committing the artifact after a code owner has approved does not merely
+invalidate the marker; it revokes the approval and forces a second review round
+for a change nobody made. Measured 2026-08-01 on clienta.ai#2214: merger-bot
+approved, the artifact commit landed, and `reviewDecision` went straight back to
+`REVIEW_REQUIRED`.
+
+This makes the ordering below load-bearing in both directions. Commit artifacts
+BEFORE requesting review, or do not commit them at all — posting the artifact as
+a PR comment satisfies `safe-merge`'s marker check on its own, since the marker
+travels in the comment body. When in doubt, prefer the comment: it cannot
+dismiss an approval, and it cannot advance HEAD.
+
+Fixed ordering:
 
 1. Write the review artifact (verdict + counts final; **no marker line yet**).
 2. Commit artifacts to the PR branch → the "Commit Review Artifact to PR Branch" step above handles `git add`/`commit`/`push` automatically (unless `--no-commit` or `PRP_RUN_ALL`). For run-all / ARTIFACT-REPORT flows, they commit all artifacts together in their own step.


### PR DESCRIPTION
The `Commit artifacts BEFORE the marker` section gives one reason the ordering matters — the marker's `head=` binding. There is a **second, independent** reason it does not mention, and in practice it bites harder.

## What happens

`dismiss_stale_reviews` discards **every approval** on any push to the PR branch. A docs-only artifact commit qualifies. So committing the review artifact after a code owner has approved does not just invalidate the marker — **it revokes the approval**, and forces a second review round for a change nobody made.

Measured 2026-08-01 on clienta.ai#2214:

```
merger-bot approves          → reviewDecision=APPROVED, mergeState=CLEAN
push artifact commit         → docs-only, .prp-output/reviews/ only
                             → reviewDecision=REVIEW_REQUIRED, mergeState=BLOCKED
```

The code owner then had to be pinged again to re-approve a byte-identical tree.

## Guidance added

> Commit artifacts BEFORE requesting review, or do not commit them at all — posting the artifact as a PR comment satisfies `safe-merge`'s marker check on its own, since the marker travels in the comment body. When in doubt, prefer the comment: it cannot dismiss an approval, and it cannot advance HEAD.

That last point is worth stating explicitly because the existing text nudges toward committing ("so `safe-merge` can find it without manual intervention"), which is the behaviour that causes this.

## Scope

All **six tracked adapters** — there is no generator for these, so they are edited in parallel. The codex and gemini copies had `Fixed ordering:` at the end of a paragraph rather than on its own line and needed a paragraph break the others did not.

## Verification

- `adapters/gemini/review-agents.toml` still parses (`tomllib`)
- new heading renders on its own line in all six (checked, not assumed — the first pass got this wrong in five files)
- docs only, no executable change

Related: gobikom/agent-devops#1003